### PR TITLE
feat: add pre-commit CI job — enforces hooks on every PR

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -298,3 +298,19 @@ jobs:
           fi
 
           echo "✅ All quality gates passed"
+
+  pre-commit:
+    name: Pre-commit Hooks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Cache pre-commit envs
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+      - name: Run pre-commit on all files
+        uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
Runs pre-commit hooks in CI using the official `pre-commit/action`. Developers don't need to run `pre-commit install` locally — violations are caught in CI regardless.

Caches hook environments keyed on `.pre-commit-config.yaml` hash for fast runs.