### PR TITLE
feat: canonical protocol contracts + governance files

### DIFF
--- a/.cursor/rules/00-core-architecture.mdc
+++ b/.cursor/rules/00-core-architecture.mdc
@@ -1,0 +1,8 @@
+---
+description: Core architecture and protocol lock
+alwaysApply: true
+---
+
+- PacketEnvelope is the canonical execution protocol.
+- Gate-compatible ingress is mandatory.
+- Contract files in `contracts/` are SSOT.

--- a/.cursor/rules/10-packet-envelope.mdc
+++ b/.cursor/rules/10-packet-envelope.mdc
@@ -1,0 +1,8 @@
+---
+description: PacketEnvelope invariants
+alwaysApply: true
+---
+
+- Preserve tenant immutability.
+- Preserve lineage derivation rules.
+- Do not add alternate network execution contracts.

--- a/.cursor/rules/20-deploy-kit.mdc
+++ b/.cursor/rules/20-deploy-kit.mdc
@@ -1,0 +1,7 @@
+---
+description: Deploy kit rules
+alwaysApply: true
+---
+
+- Generated services must pass predeploy check before readiness.
+- Generated services must expose execute, health, and readiness.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Instructions
+
+Agents must treat the following as canonical:
+- `contracts/packet_envelope_v1.yaml`
+- `contracts/conformant_node_contract.yaml`
+- `contracts/node_registration_contract.yaml`
+- `contracts/conformance_checklist.md`
+
+When generating or editing services:
+1. Read the contracts first.
+2. Preserve PacketEnvelope invariants.
+3. Keep Gate compatibility intact.
+4. Use the service manifest and generator instead of hand-building structure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,3 +111,18 @@ domains/                ← {domain_id}/spec.yaml per vertical
 - Python post-filtering of match results → gate-then-score in Cypher (contract 13)
 - Hardcoded GDS scheduling → declarative spec (contract 19)
 - eval(), exec(), pickle.load(), yaml.load() without SafeLoader → banned (contract 9)
+
+---
+
+## Protocol Lock (canonical contracts)
+
+The following files in `contracts/` are the canonical source of truth:
+- `contracts/packet_envelope_v1.yaml` — PacketEnvelope v1 schema and invariants
+- `contracts/conformant_node_contract.yaml` — conformant node requirements
+- `contracts/node_registration_contract.yaml` — node registration/capability descriptor
+- `contracts/conformance_checklist.md` — conformance self-check
+
+Rules:
+- Do not introduce alternate execution transports.
+- Do not create nodes that bypass Gate-compatible ingress.
+- PacketEnvelope and conformant-node contracts outrank informal docs and examples.

--- a/contracts/HEALTHCHECK_READINESS_SPEC.md
+++ b/contracts/HEALTHCHECK_READINESS_SPEC.md
@@ -1,0 +1,16 @@
+# Service health contract
+
+## /v1/health
+Returns:
+- service identity
+- version
+- adapter readiness flag
+
+## /v1/readiness
+Returns:
+- ready=true only after startup/preflight/registration complete
+- no internal filesystem paths
+
+## /metrics
+- optional
+- disabled by default in prod

--- a/contracts/conformance_checklist.md
+++ b/contracts/conformance_checklist.md
@@ -1,0 +1,46 @@
+# L9 Conformance Checklist
+
+A node is **conformant** only if every item below is true.
+
+## Protocol
+- [ ] Accepts PacketEnvelope over `POST /v1/execute`
+- [ ] Validates canonical packet structure before execution
+- [ ] Validates destination, action, packet type, and policy
+- [ ] Preserves tenant immutability across derivation
+- [ ] Derives responses instead of mutating inbound packets
+- [ ] Supports canonical failure packet behavior
+
+## Runtime
+- [ ] Loads typed config before serving traffic
+- [ ] Runs preflight before readiness becomes true
+- [ ] Initializes runtime state store before execution
+- [ ] Registers handlers before readiness becomes true
+- [ ] Rejects duplicate packet receipts before handler execution
+
+## HTTP surfaces
+- [ ] `GET /v1/health` exists
+- [ ] `GET /v1/readiness` exists
+- [ ] `POST /v1/execute` exists
+- [ ] `GET /metrics` is either implemented or explicitly disabled by policy
+
+## Security and policy
+- [ ] Signature behavior matches configured algorithm and policy
+- [ ] Replay policy is explicit
+- [ ] Required idempotency is enforced for configured actions
+- [ ] Attachment URI policy is enforced
+- [ ] Internal errors are sanitized by default
+
+## Deployment
+- [ ] `scripts/predeploy_check.py` passes in target environment
+- [ ] Entrypoint runs predeploy check before startup
+- [ ] Health passes after boot
+- [ ] Readiness passes after boot
+- [ ] Rollback path exists
+- [ ] Backup/restore path exists
+
+## Gate compatibility
+- [ ] Node can be registered with canonical registration contract
+- [ ] Supported actions are declared
+- [ ] Health endpoint is declared
+- [ ] Timeout is declared
+- [ ] Node can process Gate-originated PacketEnvelopes without bespoke translation

--- a/contracts/conformant_node_contract.yaml
+++ b/contracts/conformant_node_contract.yaml
@@ -1,0 +1,95 @@
+contract:
+  id: l9.conformant_node
+  version: 1.0.0
+  status: canonical
+  purpose: >-
+    Defines the minimum runtime, protocol, deployment, and operational requirements for a node
+    to be considered L9-conformant.
+
+node_role:
+  definition: >-
+    A conformant node is a service that executes work using PacketEnvelope as its canonical
+    network contract and integrates cleanly with Gate and the L9 golden template.
+
+required_http_surfaces:
+  - path: /v1/execute
+    method: POST
+    purpose: Canonical execution entrypoint.
+  - path: /v1/health
+    method: GET
+    purpose: Liveness and adapter status.
+  - path: /v1/readiness
+    method: GET
+    purpose: Runtime readiness and state-store readiness.
+optional_http_surfaces:
+  - path: /metrics
+    method: GET
+    purpose: Observability endpoint if enabled by policy.
+
+required_runtime_behaviors:
+  startup:
+    - must run typed config load before serving traffic
+    - must run preflight before readiness becomes true
+    - must initialize runtime store before accepting execution
+    - must register handlers before readiness becomes true
+  execution:
+    - must accept PacketEnvelope as canonical execution body
+    - must reject non-canonical execution payloads outside allowed dev mode
+    - must validate destination, action, packet type, signature, and policy
+    - must enforce required idempotency for configured side-effecting actions
+    - must reject duplicate packet receipts before handler execution
+    - must return PacketEnvelope response or failure packet
+  derivation:
+    - must derive child packets rather than mutate the incoming packet
+    - must preserve lineage rules from packet_envelope_v1
+    - must preserve tenant immutability
+  health:
+    - /v1/health must not depend on external network calls
+    - /v1/readiness must fail if runtime store is not usable
+
+required_configuration:
+  - environment
+  - runtime_mode
+  - node_name
+  - service_name
+  - service_version
+  - allowed_actions
+  - allowed_packet_types
+  - state_db_path
+  - signing_algorithm
+  - signature policy
+
+required_policy_controls:
+  - replay_enabled
+  - require_signature
+  - require_idempotency_for_actions
+  - attachment_allowed_schemes
+  - max_packet_bytes
+  - max_hop_depth
+  - max_delegation_depth
+  - max_attachments
+  - max_attachment_size_bytes
+
+required_deployment_controls:
+  - predeploy_check executable
+  - deterministic entrypoint
+  - health and readiness verification after startup
+  - rollback path
+  - backup and restore path
+
+required_gate_compatibility:
+  registration:
+    - must expose a stable public or internal URL
+    - must expose supported actions
+    - must declare health endpoint
+    - must declare timeout_ms
+  execution:
+    - must accept Gate-originated PacketEnvelopes without custom ingress translation
+    - must preserve Gate-issued lineage and routing metadata
+
+non_conformance_conditions:
+  - uses non-PacketEnvelope network execution contract
+  - bypasses preflight before readiness
+  - mutates tenant context across derivation
+  - lacks required health/readiness surfaces
+  - requires bespoke transport behavior outside declared protocol rules

--- a/contracts/node_registration_contract.yaml
+++ b/contracts/node_registration_contract.yaml
@@ -1,0 +1,100 @@
+contract:
+  id: l9.node_registration
+  version: 1.0.0
+  status: canonical
+  purpose: Canonical registration and capability descriptor contract for all L9 nodes.
+
+registration_key:
+  pattern: "{node_id}: {registration_object}"
+  semantics: Node registry entries are keyed by stable node identifier.
+
+registration_object:
+  required_fields:
+    - internal_url
+    - supported_actions
+    - priority_class
+    - max_concurrent
+    - health_endpoint
+    - timeout_ms
+    - metadata
+  optional_fields:
+    - public_url
+    - capability_descriptor
+    - protocol_compatibility
+    - node_class
+    - trust_tier
+    - deployment_region
+    - version
+
+field_definitions:
+  internal_url:
+    type: string
+    required: true
+    semantics: Primary route target used by Gate.
+  public_url:
+    type: string
+    required: false
+    semantics: Externally reachable URL when needed.
+  supported_actions:
+    type: list[string]
+    required: true
+    semantics: Declared actions accepted over /v1/execute.
+  priority_class:
+    type: enum
+    values: [critical, standard, experimental]
+    required: true
+  max_concurrent:
+    type: integer
+    required: true
+    min: 1
+  health_endpoint:
+    type: string
+    required: true
+  timeout_ms:
+    type: integer
+    required: true
+    min: 1
+  metadata:
+    type: object
+    required: true
+
+capability_descriptor:
+  required_fields:
+    - capability_id
+    - capability_summary
+    - capability_actions
+    - latency_profile
+    - trust_tier
+  optional_fields:
+    - confidence_profile
+    - cost_class
+    - domain_affinities
+    - specialization_tags
+    - fallback_eligible
+    - protocol_classes
+  separation_rules:
+    - identity fields must not be overloaded to represent capabilities
+    - health fields must not be overloaded to represent policy
+    - capability fields must remain semantically descriptive, not operationally incidental
+
+lifecycle_states:
+  node_lifecycle:
+    - registered
+    - active
+    - degraded
+    - draining
+    - quarantined
+    - disabled
+    - retired
+  required_gate_behaviors:
+    - only active and explicitly allowed degraded nodes may receive work
+    - draining nodes may finish work but not receive new work
+    - quarantined and disabled nodes must not receive work
+
+protocol_compatibility:
+  required_fields:
+    - packet_envelope_version
+    - compatible_packet_types
+    - signature_algorithms
+  rule: >-
+    Gate must reject registration objects that do not declare compatible protocol assumptions.

--- a/contracts/packet_envelope_v1.yaml
+++ b/contracts/packet_envelope_v1.yaml
@@ -1,0 +1,265 @@
+protocol:
+  id: l9.packet_envelope
+  title: L9 PacketEnvelope
+  version: 1.0.0
+  status: canonical
+  owners:
+    - L9 Platform
+  purpose: >-
+    Canonical execution protocol for all L9 node-to-node and consumer-to-node execution.
+  compatibility:
+    current_schema_version: "1.1"
+    backward_compatible_minor: true
+    breaking_change_policy: major_version_only
+    rule: >-
+      A node may only accept packets whose header.schema_version is supported by that node's
+      declared compatibility policy.
+  invariants:
+    - PacketEnvelope is the only canonical network execution contract.
+    - All external execution enters through Gate or an approved Gate-compatible ingress membrane.
+    - Tenant context is immutable across derived packets.
+    - Packets evolve by derivation, never mutation.
+    - envelope_hash signs the canonical envelope without the signature field.
+    - content_hash signs the canonical payload only.
+    - replay semantics are explicit and never inferred.
+    - lineage must remain reconstructable from any derived packet.
+
+packet:
+  required_sections:
+    - header
+    - address
+    - tenant
+    - payload
+    - security
+    - governance
+    - delegation_chain
+    - hop_trace
+    - lineage
+    - attachments
+
+header:
+  packet_id:
+    type: uuid
+    required: true
+    semantics: Unique identifier for this packet instance.
+  packet_type:
+    type: enum
+    required: true
+    values:
+      - request
+      - response
+      - event
+      - command
+      - delegation
+      - failure
+      - replay_request
+      - replay_response
+      - compensation
+    semantics: Canonical packet class.
+  action:
+    type: string
+    required: true
+    format: lowercase-alphanumeric-dash
+    max_length: 64
+    semantics: Declared execution action.
+  priority:
+    type: integer
+    required: true
+    range: [0, 3]
+    semantics: Execution urgency class.
+  created_at:
+    type: datetime_utc
+    required: true
+  expires_at:
+    type: datetime_utc
+    required: false
+    semantics: Hard packet TTL.
+  timeout_ms:
+    type: integer
+    required: true
+    min: 1
+    semantics: Max expected handler execution time.
+  schema_version:
+    type: string
+    required: true
+    const: "1.1"
+  idempotency_key:
+    type: string
+    required: false
+    semantics: Required for configured side-effecting actions.
+  trace_id:
+    type: string
+    required: false
+    semantics: Cross-system trace grouping key.
+  correlation_id:
+    type: string
+    required: false
+    semantics: Related packet grouping key.
+  causation_id:
+    type: uuid
+    required: false
+    semantics: Packet that directly caused this packet.
+  retry_count:
+    type: integer
+    required: true
+    min: 0
+  replay_mode:
+    type: boolean
+    required: true
+  not_before:
+    type: datetime_utc
+    required: false
+
+address:
+  source_node:
+    type: string
+    required: true
+  destination_node:
+    type: string
+    required: true
+  reply_to:
+    type: string
+    required: true
+
+tenant:
+  required_fields:
+    - actor
+    - on_behalf_of
+    - originator
+    - org_id
+  optional_fields:
+    - user_id
+  invariants:
+    - Tenant fields are immutable in all derived packets.
+    - Any change in authorization must happen through governance and delegation, not tenant rewrite.
+
+security:
+  content_hash:
+    type: sha256_hex
+    required: true
+  envelope_hash:
+    type: sha256_hex
+    required: true
+  signature:
+    type: string
+    required: false
+  signature_algorithm:
+    type: enum
+    required: false
+    values:
+      - hmac-sha256
+      - ed25519
+  signing_key_id:
+    type: string
+    required: false
+  classification:
+    type: enum
+    required: true
+    values:
+      - public
+      - internal
+      - confidential
+      - restricted
+  encryption_status:
+    type: enum
+    required: true
+    values:
+      - plaintext
+      - encrypted
+      - envelope-only
+  pii_fields:
+    type: list[string]
+    required: true
+  invariants:
+    - content_hash must match canonical payload JSON.
+    - envelope_hash must match canonical envelope JSON excluding signature.
+    - restricted packets require audit_required=true.
+
+ governance:
+  intent:
+    type: string
+    required: true
+  compliance_tags:
+    type: list[string]
+    required: true
+  retention_days:
+    type: integer
+    required: true
+  redaction_applied:
+    type: boolean
+    required: true
+  audit_required:
+    type: boolean
+    required: true
+  data_subject_id:
+    type: string
+    required: false
+
+ delegation_chain:
+  type: list[delegation_link]
+  invariants:
+    - Scope may narrow but never widen across the chain.
+    - Delegated packet action must be allowed by the terminal delegation link.
+    - Delegated packet destination must equal terminal delegatee.
+
+ hop_trace:
+  type: list[hop_entry]
+  invariants:
+    - Hop trace is append-only.
+    - Hop trace entries are chronological.
+
+lineage:
+  required_fields:
+    - root_id
+    - generation
+  optional_fields:
+    - parent_id
+  invariants:
+    - root_id remains constant across derivation.
+    - parent_id must equal the direct parent packet_id.
+    - generation increments by 1 for each derived packet.
+
+attachments:
+  type: list[attachment]
+  policy:
+    allowed_schemes_configured_per_node: true
+    dangerous_schemes_forbidden:
+      - file
+      - ftp
+    http_private_hosts_forbidden_by_default: true
+
+packet_classes:
+  request:
+    purpose: Initial execution request.
+  response:
+    purpose: Final or intermediate response to a request.
+  delegation:
+    purpose: Packet explicitly delegated to another node with scope constraints.
+  failure:
+    purpose: Error packet when execution cannot continue normally.
+  replay_request:
+    purpose: Explicit replay of a previously authorized execution path.
+  replay_response:
+    purpose: Response to replayed execution.
+  compensation:
+    purpose: Compensating action packet for rollback/reversal flows.
+
+replay_policy:
+  rules:
+    - replay_request must set replay_mode=true.
+    - replay_mode must not be set on packet types other than replay_request.
+    - replay acceptance is a node policy decision, never implicit.
+
+error_contract:
+  rules:
+    - Internal exception details must not be exposed unless explicitly configured.
+    - Failure packets must still preserve lineage, tenant, and reply semantics.
+    - Failure packet payload must remain machine-parsable.
+
+conformance:
+  mandatory_for_all_l9_nodes:
+    - Accept PacketEnvelope v1 over /v1/execute.
+    - Validate packet integrity and policy before execution.
+    - Preserve tenant immutability.
+    - Derive responses rather than mutating requests.
+    - Support health and readiness contracts.


### PR DESCRIPTION
## What

Locks PacketEnvelope v1.1 and conformant node requirements into the repo as canonical SSOT.

## Files added

| Path | Purpose |
|---|---|
| `contracts/packet_envelope_v1.yaml` | Full PacketEnvelope v1.1 schema, invariants, replay policy, error contract |
| `contracts/conformant_node_contract.yaml` | Minimum runtime, protocol, deployment, operational requirements for L9-conformant nodes |
| `contracts/node_registration_contract.yaml` | Registration/capability descriptor contract for all L9 nodes |
| `contracts/conformance_checklist.md` | Self-check for node conformance |
| `contracts/HEALTHCHECK_READINESS_SPEC.md` | /v1/health and /v1/readiness surface contract |
| `AGENTS.md` | Agent instructions — read contracts before generating/editing services |
| `CLAUDE.md` | Appended protocol lock section referencing contracts as SSOT |
| `.cursor/rules/` | 3 cursor rules for core architecture, packet envelope, deploy kit |

## Invariants enforced

- PacketEnvelope is the only canonical network execution contract
- Do not introduce alternate transports
- Contracts outrank all informal docs and examples
- Agents must read contracts before generating services

## Source

`golden_protocol_lock_pack` (2026-03-30)