### PR TITLE
feat(chassis): new files from l9-node-chassis-pack — security, idempotency, tests

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+# app package

--- a/chassis/idempotency.py
+++ b/chassis/idempotency.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import sqlite3
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class IdempotencyStore:
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+        self._conn: sqlite3.Connection | None = None
+
+    def init(self) -> None:
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute("""
+            CREATE TABLE IF NOT EXISTS packet_receipts (
+                idempotency_key TEXT NOT NULL,
+                tenant_id       TEXT NOT NULL,
+                packet_id       TEXT NOT NULL,
+                source_node     TEXT NOT NULL,
+                first_seen_at   TEXT NOT NULL DEFAULT (datetime('now')),
+                created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (idempotency_key, tenant_id)
+            )
+        """)
+        self._conn.commit()
+
+    def is_duplicate(self, idempotency_key: str, tenant_id: str) -> bool:
+        if self._conn is None:
+            raise RuntimeError("IdempotencyStore.init() not called")
+        cur = self._conn.execute(
+            "SELECT 1 FROM packet_receipts WHERE idempotency_key=? AND tenant_id=?",
+            (idempotency_key, tenant_id),
+        )
+        return cur.fetchone() is not None
+
+    def record(self, idempotency_key: str, tenant_id: str, packet_id: str, source_node: str) -> None:
+        if self._conn is None:
+            raise RuntimeError("IdempotencyStore.init() not called")
+        self._conn.execute(
+            "INSERT OR IGNORE INTO packet_receipts (idempotency_key, tenant_id, packet_id, source_node) VALUES (?,?,?,?)",
+            (idempotency_key, tenant_id, packet_id, source_node),
+        )
+        self._conn.commit()
+
+    def close(self) -> None:
+        if self._conn:
+            self._conn.close()
+            self._conn = None

--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,0 +1,1 @@
+# database package

--- a/engine/security/__init__.py
+++ b/engine/security/__init__.py
@@ -1,0 +1,1 @@
+# security package

--- a/engine/security/classification.py
+++ b/engine/security/classification.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+ALLOWED_CLASSIFICATIONS = frozenset({"PUBLIC", "INTERNAL", "CONFIDENTIAL", "RESTRICTED"})
+
+
+def validate_classification(classification: str) -> None:
+    if classification not in ALLOWED_CLASSIFICATIONS:
+        raise ValueError(f"Invalid classification {classification!r}. Allowed: {ALLOWED_CLASSIFICATIONS}")

--- a/engine/security/signature.py
+++ b/engine/security/signature.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def sign_payload(payload_bytes: bytes, secret: str) -> str:
+    return hmac.new(secret.encode(), payload_bytes, hashlib.sha256).hexdigest()
+
+
+def verify_signature(payload_bytes: bytes, secret: str, expected: str) -> bool:
+    computed = sign_payload(payload_bytes, secret)
+    result = hmac.compare_digest(computed, expected)
+    if not result:
+        logger.warning("signature_verification_failed")
+    return result

--- a/tests/integration/test_health_states.py
+++ b/tests/integration/test_health_states.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import pytest
+from chassis.health import HealthAggregator, HealthStatus
+
+
+@pytest.mark.asyncio
+async def test_all_healthy():
+    h = HealthAggregator()
+    h.register("db", lambda: _ok())
+    result = await h.check()
+    assert result["status"] == HealthStatus.HEALTHY
+
+
+@pytest.mark.asyncio
+async def test_all_unhealthy():
+    h = HealthAggregator()
+    h.register("db", lambda: _fail())
+    result = await h.check()
+    assert result["status"] == HealthStatus.UNHEALTHY
+
+
+@pytest.mark.asyncio
+async def test_degraded():
+    h = HealthAggregator()
+    h.register("db", lambda: _ok())
+    h.register("cache", lambda: _fail())
+    result = await h.check()
+    assert result["status"] == HealthStatus.DEGRADED
+
+
+@pytest.mark.asyncio
+async def test_probe_exception_counts_as_failure():
+    async def bad():
+        raise RuntimeError("boom")
+    h = HealthAggregator()
+    h.register("db", bad)
+    result = await h.check()
+    assert result["probes"]["db"] is False
+
+
+@pytest.mark.asyncio
+async def test_empty_aggregator_healthy():
+    h = HealthAggregator()
+    result = await h.check()
+    assert result["status"] == HealthStatus.HEALTHY
+
+
+async def _ok() -> bool:
+    return True
+
+async def _fail() -> bool:
+    return False

--- a/tests/integration/test_migration.py
+++ b/tests/integration/test_migration.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import sqlite3
+import pytest
+from database.init_db import apply_schema
+
+
+def test_apply_schema_creates_table(tmp_path):
+    db = str(tmp_path / "test.db")
+    apply_schema(db)
+    conn = sqlite3.connect(db)
+    cur = conn.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='packet_receipts'")
+    assert cur.fetchone() is not None
+    conn.close()
+
+
+def test_apply_schema_idempotent(tmp_path):
+    db = str(tmp_path / "test.db")
+    apply_schema(db)
+    apply_schema(db)
+    conn = sqlite3.connect(db)
+    cur = conn.execute("SELECT count(*) FROM packet_receipts")
+    assert cur.fetchone()[0] == 0
+    conn.close()
+
+
+def test_tenant_id_column_exists(tmp_path):
+    db = str(tmp_path / "test.db")
+    apply_schema(db)
+    conn = sqlite3.connect(db)
+    cur = conn.execute("PRAGMA table_info(packet_receipts)")
+    cols = [row[1] for row in cur.fetchall()]
+    assert "tenant_id" in cols
+    assert "idempotency_key" in cols
+    assert "created_at" in cols
+    conn.close()

--- a/tests/unit/test_contract_enforcement.py
+++ b/tests/unit/test_contract_enforcement.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import pytest
+from chassis.types import normalize_packet
+from chassis.contract_enforcement import enforce_packet_contract, assert_contract
+
+
+def _valid():
+    return normalize_packet({
+        "tenant_id": "t1",
+        "idempotency_key": "k1",
+        "source_node": "s", "target_node": "e",
+        "schema_version": "1.1", "packet_type": "REQUEST",
+        "payload": {"x": 1},
+        "tenant": {"actor": "a", "on_behalf_of": "b", "originator": "c", "org_id": "o1"},
+    })
+
+
+def test_valid_packet_no_violations():
+    pkt = _valid()
+    assert enforce_packet_contract(pkt) == []
+
+
+def test_missing_content_hash_violation():
+    pkt = _valid()
+    pkt.security.content_hash = ""
+    violations = enforce_packet_contract(pkt)
+    assert any("content_hash" in v for v in violations)
+
+
+def test_assert_contract_raises_on_violation():
+    pkt = _valid()
+    pkt.security.content_hash = ""
+    with pytest.raises(ValueError):
+        assert_contract(pkt)

--- a/tests/unit/test_idempotency.py
+++ b/tests/unit/test_idempotency.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import pytest
+from chassis.idempotency import IdempotencyStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = IdempotencyStore(str(tmp_path / "test.db"))
+    s.init()
+    yield s
+    s.close()
+
+
+def test_not_duplicate_initially(store):
+    assert store.is_duplicate("key-1", "tenant-a") is False
+
+
+def test_record_then_detect(store):
+    store.record("key-1", "tenant-a", "pkt-1", "ingress")
+    assert store.is_duplicate("key-1", "tenant-a") is True
+
+
+def test_cross_tenant_no_collision(store):
+    store.record("key-1", "tenant-a", "pkt-1", "ingress")
+    assert store.is_duplicate("key-1", "tenant-b") is False
+
+
+def test_idempotent_record(store):
+    store.record("key-1", "tenant-a", "pkt-1", "ingress")
+    store.record("key-1", "tenant-a", "pkt-1", "ingress")
+    assert store.is_duplicate("key-1", "tenant-a") is True

--- a/tests/unit/test_lineage.py
+++ b/tests/unit/test_lineage.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from chassis.types import normalize_packet
+
+
+def _base():
+    return normalize_packet({
+        "tenant_id": "t1", "idempotency_key": "k1",
+        "source_node": "s", "target_node": "e",
+        "schema_version": "1.1", "packet_type": "REQUEST", "payload": {},
+        "tenant": {"actor": "a", "on_behalf_of": "b", "originator": "c", "org_id": "o1"},
+    })
+
+
+def test_root_id_constant_across_hops():
+    p = _base()
+    c1 = p.derive("hop1", {})
+    c2 = c1.derive("hop2", {})
+    assert c1.lineage.root_id == p.lineage.root_id
+    assert c2.lineage.root_id == p.lineage.root_id
+
+
+def test_generation_increments():
+    p = _base()
+    c1 = p.derive("hop1", {})
+    c2 = c1.derive("hop2", {})
+    assert c1.lineage.generation == p.lineage.generation + 1
+    assert c2.lineage.generation == p.lineage.generation + 2
+
+
+def test_parent_id_points_to_parent():
+    p = _base()
+    c = p.derive("hop1", {})
+    assert c.lineage.parent_id == p.packet_id
+
+
+def test_correlation_id_preserved():
+    p = _base()
+    c = p.derive("hop1", {})
+    assert c.correlation_id == p.correlation_id

--- a/tests/unit/test_packet_envelope.py
+++ b/tests/unit/test_packet_envelope.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+import pytest
+from chassis.types import PacketEnvelope, TenantContext, LineageInfo, SecurityInfo, GovernanceInfo, normalize_packet
+
+
+def _valid_raw(**overrides):
+    base = {
+        "packet_id": "pkt-001",
+        "tenant_id": "tenant-a",
+        "correlation_id": "corr-001",
+        "idempotency_key": "idem-001",
+        "source_node": "ingress",
+        "target_node": "engine",
+        "schema_version": "1.1",
+        "packet_type": "REQUEST",
+        "payload": {"action_name": "execute"},
+        "tenant": {"actor": "user1", "on_behalf_of": "org1", "originator": "api", "org_id": "org-001"},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_normalize_valid():
+    pkt = normalize_packet(_valid_raw())
+    assert pkt.packet_id == "pkt-001"
+    assert pkt.security.content_hash != ""
+    assert pkt.security.envelope_hash != ""
+
+
+def test_schema_version_enforced():
+    with pytest.raises(ValueError, match="schema_version"):
+        normalize_packet(_valid_raw(schema_version="2.0"))
+
+
+def test_missing_tenant_actor():
+    raw = _valid_raw()
+    raw["tenant"]["actor"] = ""
+    with pytest.raises(ValueError, match="actor"):
+        normalize_packet(raw)
+
+
+def test_compute_hash_sets_both_hashes():
+    pkt = normalize_packet(_valid_raw())
+    assert len(pkt.security.content_hash) == 64
+    assert len(pkt.security.envelope_hash) == 64
+
+
+def test_derive_increments_generation():
+    pkt = normalize_packet(_valid_raw())
+    child = pkt.derive("worker", {"action_name": "describe"})
+    assert child.lineage.generation == pkt.lineage.generation + 1
+    assert child.lineage.root_id == pkt.lineage.root_id
+    assert child.lineage.parent_id == pkt.packet_id
+
+
+def test_derive_preserves_tenant_id():
+    pkt = normalize_packet(_valid_raw())
+    child = pkt.derive("worker", {})
+    assert child.tenant_id == pkt.tenant_id
+
+
+def test_append_trace():
+    pkt = normalize_packet(_valid_raw())
+    pkt.append_trace("router", "entry")
+    assert len(pkt.trace) == 1
+    assert pkt.trace[0].node == "router"
+
+
+def test_missing_idempotency_key_raises():
+    with pytest.raises(ValueError, match="idempotency_key"):
+        normalize_packet(_valid_raw(idempotency_key=""))

--- a/tests/unit/test_tenant_isolation.py
+++ b/tests/unit/test_tenant_isolation.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+import pytest
+from chassis.types import normalize_packet
+
+
+def test_mismatched_tenant_rejected():
+    raw = {
+        "tenant_id": "tenant-a",
+        "idempotency_key": "idem-1",
+        "source_node": "s", "target_node": "t",
+        "schema_version": "1.1", "packet_type": "REQUEST",
+        "payload": {},
+        "tenant": {"actor": "u", "on_behalf_of": "o", "originator": "api", "org_id": "org-1"},
+    }
+    pkt = normalize_packet(raw)
+    assert pkt.tenant_id == "tenant-a"
+
+
+def test_empty_tenant_id_rejected():
+    raw = {
+        "tenant_id": "",
+        "idempotency_key": "idem-1",
+        "source_node": "s", "target_node": "t",
+        "schema_version": "1.1", "packet_type": "REQUEST",
+        "payload": {},
+        "tenant": {"actor": "u", "on_behalf_of": "o", "originator": "api", "org_id": "org-1"},
+    }
+    with pytest.raises(ValueError, match="tenant_id"):
+        normalize_packet(raw)
+
+
+def test_tenant_fields_immutable_in_derived():
+    raw = {
+        "tenant_id": "tenant-a",
+        "idempotency_key": "idem-1",
+        "source_node": "s", "target_node": "t",
+        "schema_version": "1.1", "packet_type": "REQUEST",
+        "payload": {},
+        "tenant": {"actor": "u", "on_behalf_of": "o", "originator": "api", "org_id": "org-1"},
+    }
+    pkt = normalize_packet(raw)
+    child = pkt.derive("worker", {})
+    assert child.tenant.actor == pkt.tenant.actor
+    assert child.tenant.org_id == pkt.tenant.org_id


### PR DESCRIPTION
14 new files only (existing files skipped):
- `app/__init__.py`
- `chassis/idempotency.py`
- `engine/security/` (3 files)
- `database/__init__.py`
- `tests/integration/` (3 files)
- `tests/unit/` (5 test files)

*IgorBot · 2026-04-03*