### PR TITLE
fix: ci blockers — ruff pin, contract_registry YAML keys, conformance manifest, sbom artifact

### DIFF
--- a/.github/workflows/protocol-conformance.yml
+++ b/.github/workflows/protocol-conformance.yml
@@ -27,10 +27,10 @@ jobs:
           python -m pip install pyyaml pytest
 
       - name: Validate canonical contract alignment
-        run: python scripts/validate_contract_alignment.py --repo-root . --manifest templates/service/service.manifest.yaml
+        run: python scripts/validate_contract_alignment.py --repo-root . --manifest templates/service/service.manifest.protocol.yaml
 
       - name: Validate manifest directly
-        run: python deploy/scripts/validate_manifest.py templates/service/service.manifest.yaml
+        run: python deploy/scripts/validate_manifest.py templates/service/service.manifest.protocol.yaml
 
       - name: Run contract tests
         run: pytest tests/contracts -q

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -47,7 +47,7 @@ jobs:
           "
 
       - name: Upload SBOM artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: sbom-${{ github.sha }}
           path: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.0
+    rev: v0.15.9
     hooks:
       - id: ruff
         args: [--fix]

--- a/app/contract_registry.py
+++ b/app/contract_registry.py
@@ -33,17 +33,20 @@ class ContractBundle:
 
     @property
     def mandatory_endpoints(self) -> tuple[str, ...]:
-        endpoints = self.conformant_node['runtime_surfaces']['mandatory_http_surfaces']
-        return tuple(str(v['path']) for v in endpoints)
+        # YAML key is 'required_http_surfaces', not 'runtime_surfaces.mandatory_http_surfaces'
+        surfaces = self.conformant_node['required_http_surfaces']
+        return tuple(str(v['path']) for v in surfaces)
 
     @property
     def mandatory_service_env(self) -> tuple[str, ...]:
-        values = self.conformant_node['deployment']['required_environment_variables']
+        # YAML key is 'required_configuration', a flat list of strings
+        values = self.conformant_node['required_configuration']
         return tuple(str(v) for v in values)
 
     @property
     def required_registration_fields(self) -> tuple[str, ...]:
-        values = self.node_registration['registration_contract']['required_fields']
+        # YAML key is 'registration_object.required_fields', not 'registration_contract.required_fields'
+        values = self.node_registration['registration_object']['required_fields']
         return tuple(str(v) for v in values)
 
 


### PR DESCRIPTION
## Summary

Fixes all four code-level CI blockers from the residual blocker audit.

## Changes

### 1. `.pre-commit-config.yaml` — Ruff version alignment
- `rev: v0.9.0` → `v0.15.9`
- Aligns pre-commit with `pyproject.toml` (`ruff = "^0.15.5"`). Mismatched versions caused pre-commit to pass locally while CI failed.

### 2. `app/contract_registry.py` — Fix three wrong YAML key reads (Bug 4a + 4c)
- `mandatory_endpoints`: `runtime_surfaces.mandatory_http_surfaces` → `required_http_surfaces` (flat key in conformant_node_contract.yaml)
- `mandatory_service_env`: `deployment.required_environment_variables` → `required_configuration` (flat string list)
- `required_registration_fields`: `registration_contract.required_fields` → `registration_object.required_fields`

All three were KeyErrors at runtime — the properties read keys that don't exist in the actual YAML.

### 3. `.github/workflows/protocol-conformance.yml` — Point at correct manifest (Bug 4b)
- Both `validate_contract_alignment.py` and `validate_manifest.py` now receive `service.manifest.protocol.yaml` instead of `service.manifest.yaml`
- `service.manifest.yaml` has deployment fields only; the protocol fields (`protocol_version`, `http_surfaces`, `required_env`) only exist in `service.manifest.protocol.yaml`

### 4. `.github/workflows/sbom.yml` — Fix non-existent action version
- `actions/upload-artifact@v7` → `@v4` (v7 does not exist; latest is v4)

## Not in this PR (requires repo admin)
- GitHub Secrets: SONAR_TOKEN, GITGUARDIAN_API_KEY, CODECOV_TOKEN, TELEGRAM_BOT_TOKEN, PERPLEXITY_API_KEY
- GitHub Variables: PYTHON_VERSION, SONAR_PROJECT_KEY, SONAR_ORG
- poetry.lock generation (run `poetry lock` locally and commit)
- SonarCloud: disable Automatic Analysis in project settings → use CI-based analysis only

*IgorBot · 2026-04-03*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated protocol conformance validation workflow to reference updated manifest file paths.
  * Updated CI/CD artifact upload action version.
  * Updated development code linting tool to the latest version.
  * Modified contract registry implementation to support updated schema structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->