### PR TITLE
chore(docs): L9-aligned docs and contracts scaffold

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,63 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: ci
+  tags: [github, ci, workflows, codeowners]
+  owner: platform
+  status: active
+-->
+
+# .github/
+
+GitHub-native automation: workflows, code owners, dependency policy, release drafting.
+
+## Purpose
+
+The CI surface is where invariants are *enforced*. Auditors, contract checks, tests, and policy scans all run from here. If a check exists in `tools/` but is not wired in `.github/workflows/`, it is decoration.
+
+## What lives here
+
+| Path | Responsibility |
+|---|---|
+| `workflows/` | GitHub Actions workflows — CI, contract verification, audit, release. |
+| `CODEOWNERS` | Path-scoped review owners. Required reviewers per directory. |
+| `dependabot.yml` | Dependency update cadence and grouping. |
+| `release-drafter.yml` | Auto-draft release notes from PR labels. |
+
+## Required workflows
+
+Every workflow ships in CI. Do not remove without an ADR.
+
+- **lint-and-type** — ruff, mypy strict, shellcheck, hadolint.
+- **contracts** — `tools/verify_contracts.py` against `contracts/_schemas/l9_contract_meta.schema.json`; `scripts/validate_contract_alignment.py`.
+- **audit** — `tools/auditors/` and `tools/audit_engine.py` — fails CI on any `block`-severity finding.
+- **tests** — `pytest` over `tests/unit`, `tests/contracts`, `tests/integration`, `tests/compliance`.
+- **policy** — semgrep against `.semgrep/`, OPA bundles via `scripts/validate-policy.sh`.
+- **build** — Docker image build for `Dockerfile` and `Dockerfile.prod`, hadolint clean.
+- **review** — reviewer pipeline (`tools/review/`) on changed files.
+
+## What does NOT live here
+
+- **No application code.** Only CI, ownership, and dependency configuration.
+- **No production secrets.** Use repository secrets and OIDC federation; never embed.
+
+## Contracts that govern this directory
+
+- [`/contracts/_schemas/l9_contract_meta.schema.json`](../contracts/_schemas/l9_contract_meta.schema.json) — the contracts workflow validates every YAML against this meta-schema.
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — the audit workflow asserts handler/contract alignment.
+
+## Quality gates
+
+- Every workflow pins action versions to a SHA, never a moving tag.
+- Required status checks: `lint-and-type`, `contracts`, `audit`, `tests`, `policy`.
+- `CODEOWNERS` covers `contracts/`, `chassis/`, `engine/`, `tools/auditors/`, `docs/adr/` at minimum.
+- Branch protection requires linear history and signed commits on `main`.
+
+## Conventions
+
+- Workflow names: `lower-case-hyphenated`.
+- One workflow file per concern. No "ci.yml" mega-workflow.
+- Use reusable workflows for common matrices (`workflow_call`).
+- All workflow steps run with `set -euo pipefail` semantics where applicable.

--- a/IMPLEMENTATION_NOTE.md
+++ b/IMPLEMENTATION_NOTE.md
@@ -1,0 +1,216 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: meta
+  tags: [implementation-note, scaffold, docs, contracts]
+  owner: platform
+  status: active
+-->
+
+# Implementation Note — L9 Docs and Contracts Scaffold
+
+**Branch:** `chore/l9-docs-contracts-scaffold`
+**Scope:** Add the L9-aligned starter pack: canonical contracts, architecture and operations docs, ADR template, security and observability docs, and READMEs for every AI-system directory in the repo.
+**Non-goals:** No engine, chassis, tools, or CI code is changed in this branch. No legacy file under `contracts/*.yaml` is removed; the new canonical contracts coexist with the legacy ones during migration.
+
+This document inventories every new file added in this branch and explains its purpose.
+
+---
+
+## 1. Contracts pack (`/contracts/`)
+
+The contracts pack is the **enforcement layer**. Docs explain; contracts win. Every contract YAML carries an `L9_META` header and validates against the meta-schema below.
+
+### 1.1 Meta-schema
+
+| File | Purpose |
+|---|---|
+| `contracts/README.md` | Index of the contracts pack — what each contract owns, how they relate, who reviews changes. |
+| `contracts/_schemas/l9_contract_meta.schema.json` | JSON Schema 2020-12 meta-schema. Every `*.contract.yaml` validates against this. CI fails if a new contract YAML omits required L9 fields. |
+
+### 1.2 Transport — the canonical envelope
+
+| File | Purpose |
+|---|---|
+| `contracts/transport/transport_packet.contract.yaml` | The canonical TransportPacket contract: envelope fields, invariants, error shape. Replaces `PacketEnvelope` (now `superseded`). |
+| `contracts/transport/transport_packet.schema.json` | JSON Schema 2020-12 for the TransportPacket envelope. Used by the chassis at runtime and by `tests/contracts/`. |
+| `contracts/transport/migration_from_packet_envelope.contract.yaml` | Migration contract: maps legacy `PacketEnvelope` fields to canonical `TransportPacket`, declares deprecation timeline. |
+
+### 1.3 Routing
+
+| File | Purpose |
+|---|---|
+| `contracts/routing/routing_policy.contract.yaml` | Routing authority policy: how `action` is mapped to a target node, peer-URL hiding, fallback semantics. |
+
+### 1.4 The three authorities — Gate / Orchestrator / Runtime
+
+| File | Purpose |
+|---|---|
+| `contracts/gate/gate.contract.yaml` | Gate contract — the workflow-stateless transport authority. Defines the single execute path: `validate → route → admit → dispatch → return`. |
+| `contracts/orchestrator/orchestrator.contract.yaml` | Orchestrator contract — workflow authority. Registers as a normal node. Owns multi-step state. |
+| `contracts/runtime/runtime.contract.yaml` | Runtime contract — execution-only. Handler signature, idempotency, statelessness. |
+
+### 1.5 Registration
+
+| File | Purpose |
+|---|---|
+| `contracts/registration/node_registration.contract.yaml` | Node self-registration handshake at boot. Capabilities, action ids, health endpoints. |
+
+### 1.6 Governance
+
+| File | Purpose |
+|---|---|
+| `contracts/governance/tenant_context.contract.yaml` | Tenant context envelope field — required on every packet, preserved end-to-end. |
+| `contracts/governance/delegation_chain.contract.yaml` | Delegation chain semantics — extended on chained calls, never overwritten. |
+| `contracts/governance/prohibited_factors.contract.yaml` | Fields the engine must not read for decisioning. Static-checked by `tools/auditors/`. |
+
+### 1.7 Observability
+
+| File | Purpose |
+|---|---|
+| `contracts/observability/trace_propagation.contract.yaml` | W3C trace context propagation across the gate and between nodes. |
+| `contracts/observability/metrics.contract.yaml` | Required SLI metric set every node must expose. |
+
+---
+
+## 2. Docs pack (`/docs/`)
+
+Docs explain. They reference contracts; they do not redefine them. Every doc carries an L9_META header.
+
+### 2.1 Index and architecture
+
+| File | Purpose |
+|---|---|
+| `docs/README.md` | Index of the docs pack — section map, audience guide, contract pointers. |
+| `docs/architecture/OVERVIEW.md` | One-page overview: a node, a constellation, the gate, the canonical packet. |
+| `docs/architecture/CONSTELLATION.md` | How nodes compose into a constellation — orchestrator role, peer discovery, packet flow. |
+| `docs/architecture/ROUTING.md` | Routing model: action → target resolution; why workers must not know peer URLs. |
+
+### 2.2 Boundaries
+
+| File | Purpose |
+|---|---|
+| `docs/boundaries/GATE.md` | Gate boundary — what crosses, what doesn't, the single execute path. |
+| `docs/boundaries/ORCHESTRATOR.md` | Orchestrator boundary — workflow state lives here, not in the chassis. |
+| `docs/boundaries/RUNTIME.md` | Runtime boundary — handler invariants, idempotency, no transport authority. |
+| `docs/boundaries/WHAT_LIVES_WHERE.md` | The "what lives where" map — directory by directory, contract by contract. |
+
+### 2.3 Contracts companions
+
+Plain-English companions to the YAML contracts. Useful for onboarding.
+
+| File | Purpose |
+|---|---|
+| `docs/contracts/TRANSPORT_PACKET.md` | Companion to `transport_packet.contract.yaml`. Field walkthrough, examples, anti-patterns. |
+| `docs/contracts/ROUTING_POLICY.md` | Companion to `routing_policy.contract.yaml`. |
+| `docs/contracts/NODE_REGISTRATION.md` | Companion to `node_registration.contract.yaml`. |
+| `docs/contracts/DELEGATION_PROTOCOL.md` | Companion to `delegation_chain.contract.yaml`. Worked examples. |
+| `docs/contracts/PACKET_TYPE_REGISTRY.md` | Registry conventions: how to name and version packet types. |
+| `docs/contracts/BREAKING_CHANGE_POLICY.md` | When a change is breaking, how to ship migrations, deprecation windows. |
+
+Pre-existing files in `docs/contracts/` (e.g. `TEST_QUALITY.md`, `QUERY_PERFORMANCE.md`, `LOG_SAFETY.md`, `API_REGRESSION.md`, plus `docs/review/`, `docs/audit/`, `docs/agent-tasks/`) are preserved unchanged.
+
+### 2.4 Agents
+
+| File | Purpose |
+|---|---|
+| `docs/agents/CODING_GUIDE.md` | The coding guide for engine/handler authors. Banned imports, idempotency rules, packet patterns. |
+| `docs/agents/ORCHESTRATION_PATTERNS.md` | Patterns for multi-step workflows — saga, fan-out, retry, compensation. |
+| `docs/agents/LIFECYCLE.md` | Node lifecycle — boot, register, serve, drain, terminate. |
+
+### 2.5 Architecture decision records
+
+| File | Purpose |
+|---|---|
+| `docs/adr/README.md` | ADR index, process, status definitions. |
+| `docs/adr/TEMPLATE.md` | ADR template — context, decision, consequences, alternatives. |
+| `docs/adr/0001-transport-packet-canonical.md` | ADR-0001: TransportPacket is canonical; PacketEnvelope is superseded. |
+| `docs/adr/0002-gate-workflow-stateless.md` | ADR-0002: The gate is workflow-stateless; orchestration is a separate authority. |
+
+### 2.6 Runbooks
+
+| File | Purpose |
+|---|---|
+| `docs/runbooks/DEPLOY.md` | Deploy runbook — promotion gates, readiness checks, rollback steps. |
+| `docs/runbooks/INCIDENT.md` | Incident runbook — declare, triage, mitigate, retro. |
+| `docs/runbooks/ON_CALL.md` | On-call expectations — alert routing, response SLOs, handoff. |
+
+### 2.7 Security
+
+| File | Purpose |
+|---|---|
+| `docs/security/THREAT_MODEL.md` | Threat model for a node and a constellation. STRIDE pass over the gate path. |
+| `docs/security/SECRETS.md` | How secrets are stored, rotated, and referenced. No embedding. |
+| `docs/security/BOUNDARIES.md` | Trust boundaries: who can call what, intra-platform credentials, tenant isolation. |
+
+### 2.8 Observability
+
+| File | Purpose |
+|---|---|
+| `docs/observability/TRACING.md` | Trace propagation walkthrough. W3C `traceparent` rules. |
+| `docs/observability/METRICS.md` | Required SLI catalog with names, labels, units, semantics. |
+| `docs/observability/LOGGING.md` | Structured logging rules; what is loggable; PII redaction. |
+
+---
+
+## 3. Directory READMEs (12 files)
+
+Each README states purpose, what lives there, what does NOT live there, governing contracts, quality gates, and conventions. L9_META header on every file.
+
+| File | Directory it documents |
+|---|---|
+| `engine/README.md` | Execution surface — handlers and domain logic. |
+| `chassis/README.md` | Transport authority — gate, dispatch, middleware. |
+| `scripts/README.md` | Operational scripts — boot, deploy, audit. |
+| `tools/README.md` | Auditors, reviewers, contract verifiers. |
+| `domains/README.md` | Bounded contexts — one slice of capability per directory. |
+| `tests/README.md` | Test pyramid — unit, contracts, integration, compliance. |
+| `observability/README.md` | OTel, Prometheus, Grafana, Loki configs and dashboards. |
+| `deploy/README.md` | Release plumbing — Terraform and deploy scripts. |
+| `infrastructure/README.md` | Local Compose stacks and shared container assets. |
+| `templates/README.md` | Scaffolding generators for new services and docs. |
+| `client/README.md` | The canonical SDK — packet builder, parser, transport client. |
+| `.github/README.md` | CI workflows, code owners, dependency policy. |
+
+The repo root `README.md` is **unchanged**.
+
+---
+
+## 4. Conventions enforced by every file in this scaffold
+
+- **L9_META header** on every Markdown (HTML comment) and YAML (YAML comment) file: `l9_schema`, `origin`, `engine`, `layer`, `tags`, `owner`, `status`.
+- **No emojis** in any artifact.
+- **Frontier-lab voice** — terse, declarative, no filler.
+- **Contracts referenced, not duplicated.** Docs link to YAML; YAML is the source of truth.
+- **Canonical names**: `TransportPacket`, `gate`, `orchestrator`, `runtime`. Lowercase `snake_case` for actions and packet types.
+- **Banned**: PacketEnvelope as canonical, peer-URL knowledge in workers, FastAPI imports in `engine/`, `eval`/`exec`/`pickle.loads`/`yaml.load`.
+
+---
+
+## 5. Next steps
+
+1. **Open a PR** from `chore/l9-docs-contracts-scaffold` into `main`.
+2. **Wire contract verification into CI**:
+   - Ensure `.github/workflows/` runs `tools/verify_contracts.py` against `contracts/_schemas/l9_contract_meta.schema.json` for every YAML under `contracts/`.
+   - Wire `scripts/validate_contract_alignment.py` into the `contracts` workflow.
+3. **Owner sign-offs**:
+   - Platform owner: contracts pack and architecture docs.
+   - Security owner: `docs/security/`, `contracts/governance/`.
+   - SRE owner: `docs/runbooks/`, `docs/observability/`, `observability/`.
+4. **Migrate handlers** to declare against canonical `transport_packet.contract.yaml`. Track via `docs/contracts/BREAKING_CHANGE_POLICY.md`.
+5. **Deprecate legacy** `contracts/*.yaml` (top-level) per `migration_from_packet_envelope.contract.yaml`. Set a removal date in the next ADR.
+6. **Backfill domain contracts** under `contracts/domains/<name>/<action>.contract.yaml` for every action exposed by `domains/`.
+7. **Update CODEOWNERS** to require platform review on `contracts/` and `docs/adr/`.
+
+---
+
+## 6. What this branch does not change
+
+- No engine, chassis, tools, or CI source is modified.
+- No legacy contract file is removed.
+- No production behaviour changes — this branch is documentation and contracts only.
+- No tests are added or removed.
+
+The expected next branch is `feat/contracts-ci-wiring` to attach `tools/verify_contracts.py` and `scripts/validate_contract_alignment.py` to required CI checks.

--- a/chassis/README.md
+++ b/chassis/README.md
@@ -1,0 +1,100 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: chassis
+  tags: [chassis, transport, gate, dispatch, middleware]
+  owner: platform
+  status: active
+-->
+
+# chassis/
+
+The **transport authority** of a node. Owns the wire, the gate, and the dispatch path. Engines plug into it; they do not replace it.
+
+## Purpose
+
+`chassis/` is the only code in a node allowed to:
+
+1. Bind HTTP/gRPC sockets and parse incoming bytes.
+2. Validate `TransportPacket` envelopes against the canonical schema.
+3. Run the gate: `validate → route → admit → dispatch → return`.
+4. Emit transport-level audit events, metrics, and traces.
+5. Mint and verify intra-platform credentials.
+
+Everything past the gate is the engine's job.
+
+## What lives here
+
+| File | Responsibility |
+|---|---|
+| `chassis_app.py` | Builds the FastAPI app, mounts engine handlers, wires middleware. |
+| `engine_boot.py` | Loads engine settings, initialises services, runs startup hooks. |
+| `entrypoint.sh`, `Dockerfile.chassis` | Container boot path. |
+| `router.py` | Single execute path; resolves `action` → registered handler. |
+| `action_registry.py`, `actions.py` | Handler registration surface used by `engine/main.py`. |
+| `middleware.py` | Auth, tenant binding, trace propagation, rate limits. |
+| `health.py` | `/health/live`, `/health/ready`, `/health/startup` per the healthcheck spec. |
+| `audit.py` | Emits `audit.transport.*` events; never logs raw payload bodies. |
+| `pii.py` | Redaction helpers used before logs and audits leave the process. |
+| `contract_enforcement.py` | Schema validation hooks at request and response boundaries. |
+| `errors.py` | Typed exceptions; mapped to `TransportPacket` error responses. |
+| `orchestrator.py` | Local helper for nodes that participate in orchestrated flows (client-side; the **orchestrator authority** is a separate node). |
+| `auth/` | Credential verification, signing, key rotation. |
+| `types.py`, `config.py` | Shared transport types and chassis-only settings. |
+
+## What does NOT live here
+
+- **No business logic.** If it knows what a "user" or "invoice" is, it belongs in `engine/`.
+- **No domain handlers.** Handlers are imported from `engine/`; the chassis never defines them.
+- **No direct database calls.** The chassis does not own data; it owns transport.
+- **No workflow state.** Multi-step coordination lives in the orchestrator node.
+
+## Contracts that govern this directory
+
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — canonical envelope. The chassis is the only enforcement point.
+- [`/contracts/gate/gate.contract.yaml`](../contracts/gate/gate.contract.yaml) — single-execute-path semantics.
+- [`/contracts/registration/node_registration.contract.yaml`](../contracts/registration/node_registration.contract.yaml) — startup self-registration with the routing authority.
+- [`/contracts/observability/trace_propagation.contract.yaml`](../contracts/observability/trace_propagation.contract.yaml) — every packet enters and exits with a propagated W3C trace context.
+- [`/contracts/observability/metrics.contract.yaml`](../contracts/observability/metrics.contract.yaml) — required SLI metric set per node.
+
+## Single execute path
+
+```
+inbound bytes
+   │
+   ▼
+[ validate ] ── schema, signature, replay, size
+   │
+   ▼
+[ route    ] ── action → handler in action_registry
+   │
+   ▼
+[ admit    ] ── tenant guard, rate limit, gate policy
+   │
+   ▼
+[ dispatch ] ── handler(packet) → packet'
+   │
+   ▼
+[ return   ] ── audit, metrics, response envelope
+```
+
+Any deviation — e.g. a side-channel that bypasses `validate` — is a **gate violation** and a CI failure.
+
+## Quality gates
+
+- `tools/verify_contracts.py` enforces gate contract invariants.
+- `tests/contracts/` round-trips packets through the chassis to assert envelope stability.
+- `tests/integration/` runs the full execute path against a stubbed engine.
+- `tools/auditors/` static rules:
+  - No `engine/` import is allowed to bypass the chassis dispatch.
+  - No raw `requests`/`httpx` to peer node URLs from inside `engine/`.
+  - All logs that touch `payload` must route through `chassis/pii.py`.
+
+## Conventions
+
+- The chassis is **workflow-stateless**. Any per-request memory is held only for the lifetime of that request.
+- Packet IDs are immutable on the gate path; the chassis never rewrites `packet.id`.
+- The chassis preserves `correlation_id` and `delegation_chain` end-to-end.
+- All exits are typed: success returns a `TransportPacket`; failure returns a `TransportPacket` with `error` set, never an HTTP-only error body.

--- a/client/README.md
+++ b/client/README.md
@@ -1,0 +1,56 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: client
+  tags: [client, packet-builder, sdk, transport]
+  owner: platform
+  status: active
+-->
+
+# client/
+
+The canonical SDK for talking to a node. Everything callers need to construct, sign, send, and parse a `TransportPacket` — and nothing else.
+
+## Purpose
+
+Callers (other nodes, scripts, tests, JS frontends) must never hand-roll packets. `client/` ships the one true builder so wire compatibility is a code dependency, not a stylistic choice.
+
+## What lives here
+
+| File | Responsibility |
+|---|---|
+| `packet_builder.py` | Builds canonical `TransportPacket` objects with required envelope fields, trace context, tenant context. |
+| `request_models.py` | Typed request models for common actions; pydantic v2. |
+| `response_parser.py` | Parses inbound `TransportPacket` envelopes; raises typed errors on malformed responses. |
+| `auth.py` | Signs outbound packets and verifies inbound credentials per the chassis auth contract. |
+| `execute_client.py` | Async transport client — `await client.execute(packet)`; retries, timeouts, circuit breaker. |
+| `js/` | JavaScript SDK mirror for browser and Node consumers. |
+
+## What does NOT live here
+
+- **No business logic.** The client builds and parses; it never decides.
+- **No peer URL hardcoding.** Targets are resolved through the routing authority, not literals.
+- **No engine imports.** The SDK must be consumable as a standalone package.
+
+## Contracts that govern this directory
+
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — every packet built here must conform.
+- [`/contracts/transport/transport_packet.schema.json`](../contracts/transport/transport_packet.schema.json) — JSON Schema referenced by `response_parser.py` for validation.
+- [`/contracts/observability/trace_propagation.contract.yaml`](../contracts/observability/trace_propagation.contract.yaml) — `packet_builder.py` propagates W3C trace context.
+- [`/contracts/governance/delegation_chain.contract.yaml`](../contracts/governance/delegation_chain.contract.yaml) — chained calls extend `delegation_chain` rather than overwriting.
+
+## Quality gates
+
+- `tests/contracts/test_packet_builder.py` round-trips every packet shape.
+- `tools/auditors/` flags any module outside `client/` that constructs `TransportPacket` directly.
+- The Python SDK and JS SDK are tested against the same canonical fixtures under `tests/review_fixtures/`.
+- Any breaking change to the SDK ships an ADR under `docs/adr/` and a migration note in `docs/contracts/BREAKING_CHANGE_POLICY.md`.
+
+## Conventions
+
+- One way to build a packet: `packet_builder.build(action=..., payload=..., parent=...)`.
+- Idempotency: every outbound call carries a stable `idempotency_key` derived from inputs.
+- Retries are bounded and jittered; default policy is in `execute_client.py`.
+- The JS SDK mirrors the Python API surface 1:1; divergence requires an ADR.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,109 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [contracts]
+tags: [L9_TEMPLATE, contracts, canonical]
+owner: platform
+status: active
+/L9_META -->
+
+# L9 Contracts — Canonical Source of Truth
+
+> Contracts in this directory are **canonical**. Code conforms to contracts; contracts do not conform to code.
+> Every CI build re-validates source against these specs. A build that passes lint but violates a contract is a broken build.
+
+---
+
+## Authority Model
+
+| Layer | Role | State Model | Owns |
+|---|---|---|---|
+| **Gate** | Workflow-stateless transport authority | Operationally stateful, workflow-stateless | Validation, routing, admission, dispatch |
+| **Orchestrator** | Workflow authority (a normal node from Gate's view) | Durably stateful | Workflow DAG, replay, compensation, mission state |
+| **Runtime** | Execution-only node | Boundedly stateful | Capability execution, resource budgets, local caches |
+
+The **TransportPacket** is the single canonical execution contract. `PacketEnvelope` is superseded and exists only behind explicitly-scoped adapters.
+
+---
+
+## Directory Layout
+
+```
+contracts/
+├── README.md                          ← this file
+├── transport/
+│   ├── transport_packet.contract.yaml ← TransportPacket schema, hashing, lineage
+│   ├── transport_packet.schema.json   ← JSON Schema for runtime validation
+│   └── migration_from_packet_envelope.contract.yaml
+├── routing/
+│   └── routing_policy.contract.yaml   ← node-to-gate-to-node invariant
+├── gate/
+│   └── gate.contract.yaml             ← workflow-stateless authority RFC
+├── orchestrator/
+│   └── orchestrator.contract.yaml     ← workflow authority RFC
+├── runtime/
+│   └── runtime.contract.yaml          ← execution-only node RFC
+├── registration/
+│   └── node_registration.contract.yaml
+├── governance/
+│   ├── tenant_context.contract.yaml
+│   ├── delegation_chain.contract.yaml
+│   └── prohibited_factors.contract.yaml
+├── observability/
+│   ├── trace_propagation.contract.yaml
+│   └── metrics.contract.yaml
+└── _schemas/
+    └── l9_contract_meta.schema.json   ← meta-schema all contract YAMLs validate against
+```
+
+Legacy contracts (`packet_envelope_v1.yaml`, `node_registration_contract.yaml`, `conformant_node_contract.yaml`, `HEALTHCHECK_READINESS_SPEC.md`, `conformance_checklist.md`) remain at the top level for backward compatibility during migration to the TransportPacket-canonical surface.
+
+---
+
+## Versioning Policy
+
+- Contracts use **semantic versioning**: `{major}.{minor}.{patch}`.
+- **Major** — breaking field rename, removal, or semantic change. Requires migration plan + dual-read window.
+- **Minor** — additive fields, new enum values, additional optional sections.
+- **Patch** — clarifications, typos, non-normative examples.
+- Every contract carries `contract.id`, `contract.version`, `contract.status` in its frontmatter.
+- Statuses: `draft` → `canonical` → `superseded`. Only `canonical` is enforced in CI.
+
+---
+
+## Validation Flow
+
+1. **Authoring** — write/modify a contract YAML under the appropriate subdirectory.
+2. **Meta-schema check** — `make verify-contracts` validates the contract against `_schemas/l9_contract_meta.schema.json`.
+3. **Runtime schema check** — `transport_packet.schema.json` validates every packet on the wire (gate ingress, runtime ingress).
+4. **Architecture tests** — `tests/contracts/` enforces boundary invariants (no node-to-node calls, hop_trace growing, gate workflow-stateless).
+5. **CI gate** — build fails if any of the above fail. See `ci_enforcement_rules` in `gate/gate.contract.yaml`.
+
+---
+
+## Breaking-Change Procedure
+
+1. Open an ADR under `docs/adr/` describing the change, motivation, and migration path.
+2. Bump the contract `version` major component and mark previous version `status: superseded`.
+3. Land a dual-read adapter behind a feature flag.
+4. Migrate all consumers; remove the adapter only after every consumer reports the new contract version.
+5. Delete the superseded contract file in a follow-up release.
+
+---
+
+## Cross-Reference
+
+| Topic | Contract | Doc |
+|---|---|---|
+| Packet schema | `transport/transport_packet.contract.yaml` | `docs/contracts/TRANSPORT_PACKET.md` |
+| Routing invariant | `routing/routing_policy.contract.yaml` | `docs/architecture/ROUTING.md` |
+| Gate boundary | `gate/gate.contract.yaml` | `docs/boundaries/GATE.md` |
+| Orchestrator boundary | `orchestrator/orchestrator.contract.yaml` | `docs/boundaries/ORCHESTRATOR.md` |
+| Runtime boundary | `runtime/runtime.contract.yaml` | `docs/boundaries/RUNTIME.md` |
+| Node registration | `registration/node_registration.contract.yaml` | `docs/contracts/NODE_REGISTRATION.md` |
+| Trace propagation | `observability/trace_propagation.contract.yaml` | `docs/observability/TRACING.md` |
+
+---
+
+L9 Contracts · Canonical · Quantum AI Partners

--- a/contracts/_schemas/l9_contract_meta.schema.json
+++ b/contracts/_schemas/l9_contract_meta.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://l9.platform/contracts/_schemas/l9_contract_meta.schema.json",
+  "title": "L9 Contract Meta-Schema",
+  "description": "Every L9 contract YAML must validate against this meta-schema.",
+  "type": "object",
+  "required": ["contract"],
+  "properties": {
+    "contract": {
+      "type": "object",
+      "required": ["id", "title", "version", "status"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^l9\\.[a-z0-9_]+(\\.[a-z0-9_]+)*$"
+        },
+        "title": { "type": "string" },
+        "version": {
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+        },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "canonical", "superseded"]
+        },
+        "supersedes": { "type": "array", "items": { "type": "string" } },
+        "applies_to": { "type": "string" },
+        "authoritative_schema": { "type": "string" }
+      }
+    }
+  }
+}

--- a/contracts/gate/gate.contract.yaml
+++ b/contracts/gate/gate.contract.yaml
@@ -1,0 +1,144 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, gate]
+# tags: [L9_TEMPLATE, gate, boundary, canonical]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.gate
+  title: Gate — Workflow-Stateless Transport Authority
+  version: 1.0.0
+  status: canonical
+
+authority_model:
+  role: workflow_stateless_transport_authority
+  must:
+    - validate_incoming_transport_packet
+    - resolve_destination_via_routing_policy
+    - enforce_admission
+    - dispatch_via_transport_adapter
+    - return_transport_packet_response
+  allowed_decisions:
+    - routing
+    - admission
+    - resilience
+  must_not:
+    - make_workflow_decisions
+    - perform_decomposition
+    - branching_logic
+    - retry_semantics
+    - replay_semantics
+    - compensation_semantics
+
+state_model:
+  workflow_state: forbidden
+  allowed_operational_state:
+    - node_registry_cache
+    - circuit_breaker_state
+    - rate_limiter_state
+    - load_shedding_state
+    - backpressure_state
+    - idempotency_state
+    - replay_guard_state
+  state_properties:
+    - bounded
+    - non_authoritative
+    - discardable_without_semantic_loss
+
+single_execute_path:
+  reference_implementation: |
+    async def execute(packet: TransportPacket) -> TransportPacket:
+        validate(packet)
+        node = route(packet.header.action)
+        await admit(node)
+        response = await dispatch(node, packet)
+        return build_response(response)
+  invariants:
+    - one_path_only
+    - no_branch_on_workflow_vs_non_workflow
+    - no_branch_on_node_type
+    - no_inspection_of_payload_for_semantic_meaning
+
+module_ownership:
+  must_exist:
+    boundary:
+      - ingress_validator.py
+      - routing_policy.py
+      - context_injector.py        # strictly structural
+      - transport_codec.py
+      - response_factory.py        # strictly structural
+      - failure_factory.py         # strictly structural
+    resilience:
+      - circuit_breaker.py
+      - rate_limiter.py
+      - load_shedding.py
+      - backpressure.py
+      - admission_controller.py
+      - replay_guard.py
+      - idempotency.py
+    routing:
+      - node_registry.py
+      - dispatcher.py
+    schemas:
+      - packet.py
+      - registry.py
+    runtime:
+      - lifecycle.py
+      - http_client.py
+      - health.py
+    config:
+      - settings.py
+      - node_registry.yaml
+      - priorities.yaml
+
+forbidden_modules_in_gate:
+  - orchestration/
+  - schemas/workflow.py
+  - config/workflows.yaml
+  - boundary/workflow_dispatcher.py
+  - any_workflow_classifier
+  - any_semantic_replay_or_compensation_factory
+
+forbidden_state:
+  - workflow_schemas
+  - workflow_configs
+  - workflow_dag_logic
+  - step_state
+  - replay_meaning
+  - compensation_meaning
+
+forbidden_crossings:
+  - branch_on_is_workflow
+  - treat_orchestrator_specially
+  - bypass_routing_policy
+  - hold_workflow_dag
+  - hold_mission_state
+
+orchestrator_treatment: |
+  Orchestrator MUST be registered in NodeRegistry and treated as a normal node.
+  Gate MUST NOT have any code that distinguishes orchestrator from runtime nodes.
+
+ci_enforcement_rules:
+  build_must_fail_if:
+    - workflow_logic_in_gate
+    - PacketEnvelope_imports_in_gate
+    - direct_node_to_node_calls
+    - raw_http_posts_to_execute_bypass_gate_client
+    - packet_mutation_without_derive
+    - routing_policy_bypassed
+    - handler_signature_not_transport_packet_to_transport_packet
+    - transport_packet_schema_validation_missing_at_gate_ingress
+    - node_registration_supported_actions_empty
+  required_checks:
+    - transport_packet_schema_validation
+    - routing_policy_architecture_tests
+    - no_direct_node_calls_scan
+    - no_packet_envelope_scan
+    - gate_statelessness_checks
+    - gate_client_only_execute_entry_check
+    - hop_trace_and_lineage_tests
+    - idempotency_and_replay_tests

--- a/contracts/governance/delegation_chain.contract.yaml
+++ b/contracts/governance/delegation_chain.contract.yaml
@@ -1,0 +1,69 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, governance]
+# tags: [L9_TEMPLATE, governance, delegation]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.delegation_chain
+  title: Delegation Chain — Scoped Multi-Hop Authorization
+  version: 1.0.0
+  status: canonical
+
+definition: >-
+  An append-only ordered list of DelegationGrant entries that scope authority across multi-hop flows.
+  Carried inside every TransportPacket. Every node that further delegates appends a grant.
+
+grant_fields:
+  delegator:
+    type: string
+    required: true
+    semantics: principal granting authority
+  delegate:
+    type: string
+    required: true
+    semantics: principal receiving authority
+  scope:
+    type: array<string>
+    required: true
+    semantics: capability tokens this grant permits
+  issued_at:
+    type: string
+    format: date-time
+    required: true
+  expires_at:
+    type: string
+    format: date-time
+    required: true
+  signature:
+    type: string
+    required: false
+    semantics: optional detached signature over canonical grant
+
+invariants:
+  - append_only
+  - chain_must_root_at_originator
+  - scope_must_only_narrow_or_equal_previous_grant
+  - expired_grants_invalidate_packet
+  - signature_optional_but_strongly_recommended_for_cross_org_delegation
+
+scope_lattice:
+  description: scopes form a partial order; child grants must be ≤ parent grants.
+  examples:
+    - "execute:match" ≤ "execute:*"
+    - "read:org:acme" ≤ "read:org:*"
+
+enforcement_points:
+  - gate_ingress_validator
+  - runtime_handler_pre_execute_check
+  - orchestrator_step_authorization_check
+
+failure_modes:
+  - empty_chain_when_required:           reject_with(reason="DELEGATION_REQUIRED")
+  - expired_grant:                       reject_with(reason="DELEGATION_EXPIRED")
+  - scope_widening_violation:            reject_with(reason="SCOPE_WIDENING_FORBIDDEN")
+  - missing_root_originator_match:       reject_with(reason="DELEGATION_ROOT_MISMATCH")

--- a/contracts/governance/prohibited_factors.contract.yaml
+++ b/contracts/governance/prohibited_factors.contract.yaml
@@ -1,0 +1,61 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, governance, compliance]
+# tags: [L9_TEMPLATE, compliance, prohibited_factors]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.prohibited_factors
+  title: Prohibited Factors — Compile-Time Compliance Block
+  version: 1.0.0
+  status: canonical
+
+definition: >-
+  Fields that MUST NOT influence routing, gating, scoring, or matching decisions.
+  Enforcement is at compile time during gate/scoring validation — never a runtime check.
+
+prohibited_fields:
+  - race
+  - ethnicity
+  - religion
+  - gender
+  - age
+  - disability
+  - familial_status
+  - national_origin
+  - marital_status
+  - genetic_information
+
+enforcement:
+  layer: compile_time
+  mechanism: gate_compiler_validation
+  on_violation:
+    - fail_compilation
+    - emit_audit_event
+    - reject_domain_spec
+  audit_on_violation: true
+
+allowed_uses:
+  - non_decision_observability        # e.g., aggregate fairness metrics, opt-in
+  - compliance_reporting              # never to make a decision
+  - explicit_consented_research       # under separate governance review
+
+related_controls:
+  pii_handling:
+    declared_in: domain_spec.compliance.pii.fields
+    modes: [hash, encrypt, redact, tokenize]
+    key_source: [env, vault, kms]
+    never_logged: true
+
+audit_record_shape:
+  - timestamp
+  - tenant.org_id
+  - actor
+  - violating_field
+  - source_file
+  - source_line
+  - rejection_reason

--- a/contracts/governance/tenant_context.contract.yaml
+++ b/contracts/governance/tenant_context.contract.yaml
@@ -1,0 +1,72 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, governance]
+# tags: [L9_TEMPLATE, governance, tenant]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.tenant_context
+  title: Tenant Context — Multi-Tenancy Isolation Contract
+  version: 1.0.0
+  status: canonical
+
+definition: >-
+  TenantContext binds every TransportPacket to an organization, an actor, and a delegation chain.
+  It is immutable across derivation and is the basis for all isolation, audit, and compliance.
+
+fields:
+  actor:
+    type: string
+    required: true
+    semantics: who is performing the action right now
+  on_behalf_of:
+    type: string
+    required: true
+    semantics: who authorized this action
+  originator:
+    type: string
+    required: true
+    semantics: who started the chain (root of authority)
+  org_id:
+    type: string
+    required: true
+    semantics: tenant isolation key — every data store scopes by this
+  user_id:
+    type: string
+    required: false
+
+invariants:
+  - immutable_across_derivation
+  - org_id_never_null
+  - actor_never_null
+  - cross_tenant_reads_forbidden
+  - cross_tenant_writes_forbidden
+
+resolution_priority:
+  - x_domain_key_header
+  - x_tenant_key_header
+  - subdomain
+  - api_key_prefix
+  - envelope_explicit_override
+
+isolation_model:
+  default: database_per_tenant
+  alternatives:
+    - labeled_partition
+    - row_level_security
+  rule: chosen_isolation_model_is_per_repo_decision_documented_in_adr
+
+audit:
+  every_packet_logs:
+    - packet_id
+    - org_id
+    - actor
+    - on_behalf_of
+    - originator
+    - action
+    - timestamp
+  retention: governed_by_packet_governance_retention_days

--- a/contracts/observability/metrics.contract.yaml
+++ b/contracts/observability/metrics.contract.yaml
@@ -1,0 +1,61 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, observability]
+# tags: [L9_TEMPLATE, observability, metrics, prometheus]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.metrics
+  title: L9 Metrics Contract
+  version: 1.0.0
+  status: canonical
+
+emission_target: prometheus_open_metrics
+required_endpoint: GET /metrics
+
+sdk_required_metrics:
+  - transport_packets_received_total
+  - transport_packets_sent_total
+  - transport_packet_failures_total
+  - transport_propagation_failures_total
+  - transport_span_creation_failures_total
+  - transport_hop_duration_ms
+
+gate_required_metrics:
+  - gate_dispatch_latency_ms
+  - gate_routing_failures_total
+  - gate_trace_context_missing_total
+  - gate_admission_denials_total{reason}
+  - gate_circuit_breaker_state{node}
+  - gate_idempotency_cache_hits_total
+
+orchestrator_required_metrics:
+  - orchestrator_workflow_decision_latency_ms
+  - orchestrator_trace_link_failures_total
+  - workflows_started_total
+  - workflows_completed_total{terminal_status}
+  - orchestrator_replay_total{outcome}
+  - orchestrator_compensation_total{outcome}
+
+runtime_required_metrics:
+  - runtime_handler_latency_ms{action}
+  - runtime_handler_failures_total{action,reason}
+  - runtime_resource_budget_exceeded_total{budget_kind}
+  - runtime_concurrent_executions{action}
+
+cardinality_rules:
+  - never_label_with_packet_id
+  - never_label_with_user_id
+  - never_label_with_free_form_strings
+  - tenant_id_label_must_be_org_id_only
+  - action_label_must_be_from_registered_set
+
+slo_targets_default:
+  gate_dispatch_p99_ms: 25
+  runtime_handler_p99_ms: 200
+  workflow_e2e_success_rate: 0.999
+  trace_completeness: 0.995

--- a/contracts/observability/trace_propagation.contract.yaml
+++ b/contracts/observability/trace_propagation.contract.yaml
@@ -1,0 +1,84 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, observability]
+# tags: [L9_TEMPLATE, observability, otel, tracing]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.trace_propagation
+  title: Trace Propagation — OpenTelemetry over TransportPacket
+  version: 1.0.0
+  status: canonical
+
+authority: sdk_and_transport_contract
+
+core_rule: >-
+  OpenTelemetry propagation is owned by the SDK and transport contract.
+  Nodes may enrich traces with attributes and child spans; nodes must not
+  redefine propagation semantics or workflow authority boundaries.
+
+required_trace_fields:
+  - header.trace_id
+
+optional_trace_fields:
+  - header.span_id
+  - header.trace_flags
+  - header.tracestate
+
+trace_field_rules:
+  - header.trace_id_must_be_preserved_across_derivation
+  - header.trace_flags_must_be_preserved_if_present
+  - header.tracestate_must_be_preserved_if_present
+  - header.span_id_may_change_only_when_new_boundary_span_is_created
+  - missing_trace_id_generates_new_valid_trace_id
+  - malformed_trace_context_replaced_with_new_valid_trace_and_diagnostic_by_default
+
+ownership_split:
+  sdk_owns:
+    - trace_context_extraction
+    - trace_context_injection
+    - span_creation_at_transport_boundaries
+    - transport_metrics_emission
+    - hop_timing_capture
+    - propagation_consistency
+  gate_owns:
+    - preserving_inbound_trace_context
+    - creating_gate_dispatch_spans
+    - annotating_routing_events
+    - preserving_trace_across_dispatch
+  orchestrator_owns:
+    - creating_workflow_decision_spans
+    - adding_workflow_attributes_to_spans
+    - correlating_trace_context_with_workflow_state
+  runtime_owns:
+    - creating_execution_spans
+    - creating_validation_spans
+    - adding_execution_attributes_and_events
+    - emitting_execution_metrics
+  governance_owns:
+    - observability_contract_enforcement
+    - forbidden_behavior_detection
+
+required_transport_spans:
+  - gate_ingress
+  - gate_dispatch
+  - node_receive
+  - node_handler
+  - node_emit
+
+minimum_common_attributes:
+  - trace_id
+  - node_name
+  - action
+  - tenant_id
+  - packet_type
+  - root_id
+
+forbidden:
+  - detached_async_trace_forks_without_governed_policy
+  - replacing_valid_inbound_trace_id
+  - using_trace_data_as_hidden_control_plane

--- a/contracts/orchestrator/orchestrator.contract.yaml
+++ b/contracts/orchestrator/orchestrator.contract.yaml
@@ -1,0 +1,133 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, orchestrator]
+# tags: [L9_TEMPLATE, orchestrator, workflow, canonical]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.orchestrator
+  title: Orchestrator — Workflow Authority Node
+  version: 1.0.0
+  status: canonical
+
+identity: normal_node_from_gate_perspective
+
+authority_model:
+  role: workflow_authority
+  must:
+    - decompose_tasks_into_steps
+    - sequence_execution
+    - manage_branching_logic
+    - define_retry_semantics
+    - define_replay_semantics
+    - define_compensation_semantics
+    - merge_results
+    - produce_terminal_outcomes
+  must_not:
+    - route_packets_directly
+    - bypass_gate
+    - own_transport_logic
+    - admission_control
+    - private_node_registry
+
+transport_boundary:
+  ingress: TransportPacket
+  egress: TransportPacket_via_GateClient
+
+state_model:
+  workflow_state: required
+  durability: required
+  replayable: required
+  auditable: required
+  owned_state:
+    - workflow_dag
+    - step_state
+    - execution_history
+    - replay_state
+    - compensation_state
+    - terminal_outcomes
+    - mission_state
+    - checkpoint_state
+
+execution_model:
+  loop:
+    - receive_transport_packet
+    - load_or_create_workflow_state
+    - evaluate_next_step_or_steps
+    - emit_subtask_transport_packet_via_gate
+    - update_state
+    - repeat_until_terminal
+  invariants:
+    - all_subtask_dispatch_goes_through_gate
+    - preserve_trace_id
+    - preserve_lineage
+    - no_arbitrary_trace_forking
+    - no_hidden_workflow_state
+
+module_ownership:
+  engine:
+    - orchestration_engine.py
+    - condition_evaluator.py
+    - decomposability_classifier.py
+    - payload_transformer.py
+    - deadline_propagator.py
+  compensation:
+    - saga_manager.py
+    - checkpoint_store.py
+  schemas:
+    - workflow.py
+  config:
+    - workflows.yaml
+    - orchestrator_settings.py
+  api:
+    - main.py
+    - transport_adapter.py
+
+mission_kernel:
+  location: orchestrator_only
+  ownership: exclusive
+  responsibilities:
+    - load_or_create_mission_state
+    - checkpoint
+    - restore
+    - branch
+    - merge
+    - aggregate
+    - decide_next_step
+  forbidden_outside_orchestrator:
+    - gate
+    - runtime_nodes
+    - gate_client
+
+forbidden_crossings:
+  - direct_runtime_node_calls
+  - custom_transport_routing_logic
+  - private_node_registry
+  - admission_control
+  - gate_bypass
+  - special_semantic_ingress_as_architectural_identity
+
+integration_rules:
+  - all_outbound_packets_go_through_gate
+  - use_sdk_transport_layer
+  - preserve_trace_id_and_lineage
+  - never_fork_traces_arbitrarily
+
+registration_example:
+  orchestrator:
+    internal_url: "http://orchestrator:8001"
+    supported_actions:
+      - research_report
+      - multi_step_analysis
+      - workflow_execute
+      - plan_and_solve
+    priority_class: P0
+    max_concurrent: 20
+    health_endpoint: /v1/health
+    timeout_ms: 300000
+    metadata:
+      node_type: orchestrator

--- a/contracts/registration/node_registration.contract.yaml
+++ b/contracts/registration/node_registration.contract.yaml
@@ -1,0 +1,91 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, registration]
+# tags: [L9_TEMPLATE, registration, node]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.node_registration
+  title: Node Registration Contract
+  version: 1.0.0
+  status: canonical
+
+endpoint:
+  path: /v1/admin/register
+  method: POST
+  authentication: gate_admin_credential
+
+payload_shape: top_level_json_object_keyed_by_node_name
+
+required_fields:
+  - internal_url
+  - supported_actions
+
+optional_fields:
+  - priority_class
+  - max_concurrent
+  - health_endpoint
+  - timeout_ms
+  - metadata
+  - public_url
+  - capability_descriptor
+  - protocol_compatibility
+  - node_class
+  - trust_tier
+  - deployment_region
+  - version
+
+field_definitions:
+  internal_url:
+    type: string
+    required: true
+    constraints: [absolute_url]
+    semantics: Primary route target used by Gate.
+  supported_actions:
+    type: array<string>
+    required: true
+    constraints: [non_empty, lowercase_snake_case]
+  priority_class:
+    type: string
+    enum: [P0, P1, P2, P3]
+    default: P2
+  max_concurrent:
+    type: integer
+    minimum: 1
+    default: 8
+  health_endpoint:
+    type: string
+    default: /v1/health
+  timeout_ms:
+    type: integer
+    minimum: 100
+    default: 30000
+  metadata:
+    type: object
+    description: Free-form metadata; reserved keys 'node_type', 'region', 'version'.
+
+rules:
+  - node_names_normalized_to_lowercase
+  - supported_actions_must_be_non_empty
+  - internal_url_must_be_absolute
+  - gate_is_authoritative_for_activation_and_health_state
+  - registration_may_be_rejected_if_overwrite_false_and_node_exists
+  - orchestrator_registers_as_a_normal_node
+
+example:
+  enrichment-engine:
+    internal_url: "http://enrichment-engine:8001"
+    supported_actions:
+      - enrich
+      - enrichment_request
+    priority_class: P1
+    max_concurrent: 16
+    health_endpoint: /v1/health
+    timeout_ms: 60000
+    metadata:
+      node_type: runtime
+      version: 1.4.2

--- a/contracts/routing/routing_policy.contract.yaml
+++ b/contracts/routing/routing_policy.contract.yaml
@@ -1,0 +1,69 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, routing]
+# tags: [L9_TEMPLATE, routing, gate]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.routing_policy
+  title: L9 Routing Policy
+  version: 1.0.0
+  status: canonical
+
+core_rule: all_node_originated_follow_up_traffic_must_return_to_gate
+
+allowed_patterns:
+  - client_to_gate
+  - node_to_gate
+  - gate_to_worker
+
+forbidden_patterns:
+  - node_a_to_node_b
+  - orchestrator_to_worker_direct
+  - worker_to_worker_direct
+
+invariant: workers_must_not_know_peer_urls
+
+node_origin_packet_requirements:
+  provenance:
+    origin_kind: node
+    resolved_by_gate: false
+    original_source_node: local_node
+  address:
+    source_node: local_node
+    destination_node: gate
+
+gate_dispatch_packet_requirements:
+  provenance:
+    origin_kind: gate
+    resolved_by_gate: true
+  address:
+    source_node: gate
+    destination_node: resolved_worker_node
+
+enforcement_points:
+  - sdk_gate_client
+  - gate_ingress_validator
+  - gate_routing_policy_validator
+  - architecture_tests
+
+selection_algorithm:
+  input: header.action
+  resolution:
+    - lookup_action_in_node_registry
+    - filter_by_health_active
+    - filter_by_priority_class_eligibility
+    - apply_admission_controller
+  failure_modes:
+    - action_not_registered:        return failure_packet(reason="UNROUTABLE")
+    - no_healthy_node:              return failure_packet(reason="NODE_UNAVAILABLE")
+    - admission_denied:             return failure_packet(reason="ADMISSION_DENIED")
+
+ci_tests:
+  - tests/contracts/test_no_direct_node_calls.py
+  - tests/contracts/test_node_origin_packet_addresses_gate.py
+  - tests/contracts/test_gate_dispatch_packet_provenance.py

--- a/contracts/runtime/runtime.contract.yaml
+++ b/contracts/runtime/runtime.contract.yaml
@@ -1,0 +1,79 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, runtime]
+# tags: [L9_TEMPLATE, runtime, execution, canonical]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.runtime
+  title: Runtime — Execution-Only Node
+  version: 1.0.0
+  status: canonical
+
+identity: pure_execution_unit
+ingress: TransportPacket
+egress: TransportPacket
+
+handler_contract:
+  signature: "async def handler(packet: TransportPacket) -> TransportPacket"
+
+authority_model:
+  role: execution_only
+  must:
+    - validate_packet
+    - execute_action_handler
+    - return_response_packet
+    - enforce_resource_budgets
+    - preserve_trace_context
+    - respect_concurrency_limits
+  must_not:
+    - decide_next_workflow_step
+    - trigger_retries_or_compensation
+    - perform_routing
+    - maintain_workflow_control
+    - call_other_nodes_directly
+    - call_gate_bypassing_sdk
+    - emit_follow_up_packets_without_orchestrator_authority
+
+state_model:
+  bounded_state_only: true
+  allowed_local_state:
+    - execution_local_state
+    - caches
+    - model_or_session_state
+    - tool_state
+  forbidden_state:
+    - workflow_dag
+    - cross_step_orchestration_state
+    - replay_authority
+    - compensation_authority
+    - authoritative_workflow_truth
+
+execution_properties:
+  - isolated
+  - bounded
+  - deterministic_where_possible
+  - stateless_where_possible
+
+module_ownership:
+  execution:
+    - agent_executor.py
+    - resource_budget.py
+    - state_manager.py
+  memory:
+    - semantic_retriever.py
+    - episodic_store.py
+  scaling:
+    - autoscaler.py
+    - pool_manager.py
+
+guarantees:
+  - respect_resource_limits
+  - return_explicit_success_or_failure
+  - include_diagnostics
+  - preserve_trace_context
+  - hop_trace_appended_with_node_name

--- a/contracts/transport/migration_from_packet_envelope.contract.yaml
+++ b/contracts/transport/migration_from_packet_envelope.contract.yaml
@@ -1,0 +1,72 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, transport, migration]
+# tags: [L9_TEMPLATE, migration, transport_packet]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.migration.packet_envelope_to_transport_packet
+  title: PacketEnvelope → TransportPacket Migration
+  version: 1.0.0
+  status: canonical
+  applies_to: l9.transport_packet@1.0.0
+
+status_table:
+  PacketEnvelope: superseded
+  TransportPacket: canonical
+
+mandatory_steps:
+  - replace_envelope_creation_with_canonical_transport_packet_creation
+  - remove_all_node_to_node_calls
+  - route_all_follow_up_traffic_node_to_gate_to_node
+  - add_and_validate_provenance_fields
+  - update_handlers_to_accept_transport_packet_and_return_transport_packet
+  - enforce_idempotency_key_for_critical_flows
+  - require_hop_trace_presence_and_growth
+  - bind_runtime_validation_to_transport_packet_schema_json
+
+common_failures:
+  - partial_migration
+  - mixed_envelope_models
+  - missing_provenance
+  - direct_dispatch
+  - raw_execute_dict_posting
+  - gate_acquiring_workflow_state
+
+validation_checklist:
+  - all_requests_use_transport_packet
+  - no_direct_node_to_node_calls
+  - hop_trace_present
+  - hop_trace_growing
+  - idempotency_enforced_where_required
+  - replay_protection_active
+  - gate_remains_workflow_stateless
+  - orchestrator_owns_workflow_state
+  - runtime_nodes_are_execution_only
+
+backward_compatibility_policy:
+  legacy_packet_envelope_support:
+    default: false
+    allowed_only_if:
+      - explicitly_scoped_adapter
+      - isolated_compatibility_boundary
+      - never_reintroduced_as_canonical
+  forbidden_after_migration:
+    - packet_envelope_as_ingress_truth
+    - packet_envelope_as_runtime_truth
+    - mixed_transport_models
+    - mission_kernel_inside_runtime_nodes
+    - direct_raw_execute_payload_posting
+
+handler_signature_migration:
+  before: "async def handler(envelope: PacketEnvelope) -> dict"
+  after:  "async def handler(packet: TransportPacket) -> TransportPacket"
+
+dual_read_window:
+  duration: one_release_cycle
+  adapter_location: chassis/legacy/packet_envelope_adapter.py
+  removal_trigger: all_consumers_report_transport_packet_v1_0_0

--- a/contracts/transport/transport_packet.contract.yaml
+++ b/contracts/transport/transport_packet.contract.yaml
@@ -1,0 +1,238 @@
+# --- L9_META ---
+# l9_schema: 1
+# origin: l9-template
+# engine: golden-repo
+# layer: [contracts, transport]
+# tags: [L9_TEMPLATE, contracts, transport_packet, canonical]
+# owner: platform
+# status: active
+# --- /L9_META ---
+
+contract:
+  id: l9.transport_packet
+  title: TransportPacket — Canonical Execution Contract
+  version: 1.0.0
+  status: canonical
+  supersedes:
+    - l9.packet_envelope
+    - l9.agent_packet
+    - raw_execute_payloads
+  authoritative_schema: contracts/transport/transport_packet.schema.json
+
+invariants:
+  - TransportPacket is the only canonical network execution contract.
+  - All external execution enters through Gate.
+  - Tenant context is immutable across derived packets.
+  - Packets evolve by derivation, never mutation.
+  - transport_hash signs the canonical envelope without hop_trace.
+  - payload_hash signs the canonical payload only.
+  - lineage must remain reconstructable from any derived packet.
+  - hop_trace is append-only and tamper-evident.
+
+construction_rules:
+  immutable_execution_record: true
+  in_place_mutation: forbidden
+  semantic_change_requires: derive
+  observational_route_journal_requires: with_hop
+
+packet:
+  required_sections:
+    - header
+    - address
+    - tenant
+    - payload
+    - security
+    - governance
+    - provenance
+    - delegation_chain
+    - hop_trace
+    - lineage
+    - attachments
+
+  header:
+    required:
+      - packet_id           # UUIDv4 — globally unique
+      - packet_type         # enum below
+      - action              # routing key, lowercase snake_case
+      - priority            # 0..3 (P0..P3)
+      - created_at          # ISO 8601 UTC
+      - timeout_ms          # int, > 0
+      - schema_version      # semver of this contract
+      - retry_count         # int, default 0
+      - replay_mode         # enum: none | replay_request | replay_response
+    optional:
+      - idempotency_key     # gate-enforced dedup
+      - trace_id            # W3C; if absent, SDK generates
+      - span_id
+      - trace_flags
+      - tracestate
+    constraints:
+      packet_type_enum:
+        - request
+        - response
+        - event
+        - command
+        - delegation
+        - failure
+        - replay_request
+        - replay_response
+        - compensation
+      priority_range:
+        min: 0
+        max: 3
+
+  address:
+    required:
+      - source_node         # lowercase, hyphenated
+      - destination_node
+      - reply_to
+
+  tenant:
+    required:
+      - actor               # who is doing it
+      - on_behalf_of        # who authorized it
+      - originator          # who started the chain
+      - org_id              # tenant isolation key
+    optional:
+      - user_id
+
+  payload:
+    type: object
+    description: Action-specific data. The only field that varies per domain.
+    constraints:
+      - must be JSON-serializable
+      - must be the input the destination handler expects
+
+  security:
+    required:
+      - payload_hash        # sha256 of canonical payload
+      - transport_hash      # sha256 of stable packet core (excludes hop_trace)
+      - classification      # public | internal | confidential | restricted
+      - encryption_status   # plaintext | encrypted_at_rest | encrypted_in_transit
+      - pii_fields          # list[str] declared PII paths
+    optional:
+      - transport_signature # detached signature over transport_hash
+      - hop_signature       # optional per-hop signature
+
+  governance:
+    required:
+      - intent              # business intent for audit
+      - compliance_tags     # list[str]
+      - retention_days      # int
+      - redaction_applied   # bool
+      - audit_required      # bool
+
+  provenance:
+    required:
+      - origin_kind         # client | gate | node
+      - requested_action
+      - resolved_by_gate    # bool
+    optional:
+      - original_source_node
+
+  delegation_chain:
+    type: array
+    description: Append-only chain of scoped authorizations.
+    item_required:
+      - delegator
+      - delegate
+      - scope
+      - issued_at
+      - expires_at
+
+  hop_trace:
+    type: array
+    properties:
+      - append_only
+      - tamper_evident
+    item_required:
+      - node_name
+      - received_at
+      - emitted_at
+      - hop_outcome         # received | dispatched | executed | failed
+    excluded_from_transport_hash: true
+
+  lineage:
+    required:
+      - root_id             # UUID of the origin packet
+      - generation          # 0 = root, increments per derive
+      - parent_id           # null for root
+    optional:
+      - derivation_type     # enrichment | inference | match | delegation | response
+
+  attachments:
+    type: array
+    description: Out-of-band references (URIs). Never embed raw blobs.
+    item_required:
+      - uri
+      - sha256
+      - size_bytes
+      - media_type
+
+hashing_and_signatures:
+  payload_hash:
+    algorithm: sha256
+    input: canonical_json(payload)
+  transport_hash:
+    algorithm: sha256
+    input: canonical_json(header + address + tenant + payload + security + governance + provenance + delegation_chain + lineage + attachments + payload_hash)
+    excludes:
+      - hop_trace
+  signature_model:
+    transport_signature:
+      purpose:
+        - sender_authenticity
+        - semantic_packet_integrity
+    hop_signature:
+      optional: true
+      purpose:
+        - hop_level_authenticity
+        - tamper_evident_routing_journal
+
+lineage_rules:
+  root_packet:
+    parent_id: null
+    generation: 0
+    root_id: self.packet_id
+  child_packet:
+    parent_id: parent.packet_id
+    root_id: parent.root_id
+    generation: parent.generation + 1
+
+response_rules:
+  must_be_transport_packet: true
+  preserve_original_packet_id: true
+  reverse_address_direction: true
+  carry_execution_result_in_payload: true
+
+idempotency:
+  location: header.idempotency_key
+  enforcement_owner: gate
+  cache_value: full_response_packet
+  invariant: same_idempotency_key_returns_same_response_packet
+
+replay_protection:
+  identity: header.packet_id
+  enforcement_owner: gate
+  scope: transport_level_duplication
+
+anti_patterns:
+  - direct_node_to_node_calls
+  - in_place_packet_mutation
+  - multiple_transport_schemas
+  - raw_http_execute_calls_with_untyped_dicts
+  - PacketEnvelope_as_active_canonical_contract
+
+ci_enforcement:
+  required_checks:
+    - transport_packet_schema_validation
+    - hop_trace_append_only_tests
+    - lineage_reconstruction_tests
+    - transport_hash_stability_tests
+    - idempotency_and_replay_tests
+  build_must_fail_if:
+    - PacketEnvelope_imports_in_transportpacket_native_repos
+    - direct_node_to_node_calls
+    - raw_http_posts_to_execute_bypass_gate_client
+    - packet_mutation_without_derive
+    - transport_packet_schema_validation_missing

--- a/contracts/transport/transport_packet.schema.json
+++ b/contracts/transport/transport_packet.schema.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://l9.platform/contracts/transport/transport_packet.schema.json",
+  "title": "TransportPacket",
+  "description": "Canonical L9 execution contract. Validated at every gate ingress and node ingress.",
+  "type": "object",
+  "required": [
+    "header",
+    "address",
+    "tenant",
+    "payload",
+    "security",
+    "governance",
+    "provenance",
+    "delegation_chain",
+    "hop_trace",
+    "lineage",
+    "attachments"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "header": {
+      "type": "object",
+      "required": [
+        "packet_id",
+        "packet_type",
+        "action",
+        "priority",
+        "created_at",
+        "timeout_ms",
+        "schema_version",
+        "retry_count",
+        "replay_mode"
+      ],
+      "properties": {
+        "packet_id": { "type": "string", "format": "uuid" },
+        "packet_type": {
+          "type": "string",
+          "enum": [
+            "request",
+            "response",
+            "event",
+            "command",
+            "delegation",
+            "failure",
+            "replay_request",
+            "replay_response",
+            "compensation"
+          ]
+        },
+        "action": { "type": "string", "pattern": "^[a-z][a-z0-9_]*$" },
+        "priority": { "type": "integer", "minimum": 0, "maximum": 3 },
+        "created_at": { "type": "string", "format": "date-time" },
+        "timeout_ms": { "type": "integer", "minimum": 1 },
+        "schema_version": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+        "retry_count": { "type": "integer", "minimum": 0 },
+        "replay_mode": {
+          "type": "string",
+          "enum": ["none", "replay_request", "replay_response"]
+        },
+        "idempotency_key": { "type": "string" },
+        "trace_id": { "type": "string" },
+        "span_id": { "type": "string" },
+        "trace_flags": { "type": "string" },
+        "tracestate": { "type": "string" }
+      }
+    },
+    "address": {
+      "type": "object",
+      "required": ["source_node", "destination_node", "reply_to"],
+      "properties": {
+        "source_node": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "destination_node": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "reply_to": { "type": "string" }
+      }
+    },
+    "tenant": {
+      "type": "object",
+      "required": ["actor", "on_behalf_of", "originator", "org_id"],
+      "properties": {
+        "actor": { "type": "string" },
+        "on_behalf_of": { "type": "string" },
+        "originator": { "type": "string" },
+        "org_id": { "type": "string" },
+        "user_id": { "type": ["string", "null"] }
+      }
+    },
+    "payload": { "type": "object" },
+    "security": {
+      "type": "object",
+      "required": [
+        "payload_hash",
+        "transport_hash",
+        "classification",
+        "encryption_status",
+        "pii_fields"
+      ],
+      "properties": {
+        "payload_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "transport_hash": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+        "classification": {
+          "type": "string",
+          "enum": ["public", "internal", "confidential", "restricted"]
+        },
+        "encryption_status": {
+          "type": "string",
+          "enum": ["plaintext", "encrypted_at_rest", "encrypted_in_transit"]
+        },
+        "pii_fields": { "type": "array", "items": { "type": "string" } },
+        "transport_signature": { "type": ["string", "null"] },
+        "hop_signature": { "type": ["string", "null"] }
+      }
+    },
+    "governance": {
+      "type": "object",
+      "required": [
+        "intent",
+        "compliance_tags",
+        "retention_days",
+        "redaction_applied",
+        "audit_required"
+      ],
+      "properties": {
+        "intent": { "type": "string" },
+        "compliance_tags": { "type": "array", "items": { "type": "string" } },
+        "retention_days": { "type": "integer", "minimum": 0 },
+        "redaction_applied": { "type": "boolean" },
+        "audit_required": { "type": "boolean" }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "required": ["origin_kind", "requested_action", "resolved_by_gate"],
+      "properties": {
+        "origin_kind": {
+          "type": "string",
+          "enum": ["client", "gate", "node"]
+        },
+        "requested_action": { "type": "string" },
+        "resolved_by_gate": { "type": "boolean" },
+        "original_source_node": { "type": ["string", "null"] }
+      }
+    },
+    "delegation_chain": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["delegator", "delegate", "scope", "issued_at", "expires_at"],
+        "properties": {
+          "delegator": { "type": "string" },
+          "delegate": { "type": "string" },
+          "scope": { "type": "array", "items": { "type": "string" } },
+          "issued_at": { "type": "string", "format": "date-time" },
+          "expires_at": { "type": "string", "format": "date-time" }
+        }
+      }
+    },
+    "hop_trace": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["node_name", "received_at", "emitted_at", "hop_outcome"],
+        "properties": {
+          "node_name": { "type": "string" },
+          "received_at": { "type": "string", "format": "date-time" },
+          "emitted_at": { "type": "string", "format": "date-time" },
+          "hop_outcome": {
+            "type": "string",
+            "enum": ["received", "dispatched", "executed", "failed"]
+          },
+          "hop_signature": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "lineage": {
+      "type": "object",
+      "required": ["root_id", "generation", "parent_id"],
+      "properties": {
+        "root_id": { "type": "string", "format": "uuid" },
+        "generation": { "type": "integer", "minimum": 0 },
+        "parent_id": { "type": ["string", "null"], "format": "uuid" },
+        "derivation_type": {
+          "type": ["string", "null"],
+          "enum": [null, "enrichment", "inference", "match", "delegation", "response"]
+        }
+      }
+    },
+    "attachments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["uri", "sha256", "size_bytes", "media_type"],
+        "properties": {
+          "uri": { "type": "string", "format": "uri" },
+          "sha256": { "type": "string", "pattern": "^[a-f0-9]{64}$" },
+          "size_bytes": { "type": "integer", "minimum": 0 },
+          "media_type": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -1,0 +1,58 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: deploy
+  tags: [deploy, terraform, scripts, release]
+  owner: platform
+  status: active
+-->
+
+# deploy/
+
+Release plumbing. Terraform modules and deploy scripts that turn a built artifact into a running node.
+
+## Purpose
+
+Move a versioned image into an environment with explicit, reviewable, idempotent steps. No ad-hoc `kubectl apply`, no untracked Terraform.
+
+## What lives here
+
+| Path | Responsibility |
+|---|---|
+| `deploy/scripts/` | Imperative deploy scripts — image promotion, smoke tests, rollback. |
+| `deploy/terraform/` | Declarative environment definition — networking, IAM, cluster bindings, secrets references. |
+
+## What does NOT live here
+
+- **No application code.** This directory ships infra, not features.
+- **No image builds.** Image build lives in root `Dockerfile.prod` and CI.
+- **No production secrets.** Secrets are referenced; never embedded. See `docs/security/SECRETS.md`.
+- **No environment-specific Python.** If you need logic, write it in `tools/deploy/` and call it from a script here.
+
+## Contracts that govern this directory
+
+- [`/contracts/registration/node_registration.contract.yaml`](../contracts/registration/node_registration.contract.yaml) — deploy steps must register the node with the routing authority before traffic is admitted.
+- [`/contracts/observability/metrics.contract.yaml`](../contracts/observability/metrics.contract.yaml) — readiness gates assert SLI exposure before promotion.
+
+## Deploy invariants
+
+1. **Plan before apply.** Every Terraform change ships a captured plan in the PR.
+2. **Health gates.** Promotion waits on `/health/ready` and a minimum SLI window per `docs/runbooks/DEPLOY.md`.
+3. **Rollback is a first-class step.** Every script ships a rollback path; CI fails if missing.
+4. **No drift.** Terraform state is the source of truth; manual changes are reverted.
+
+## Quality gates
+
+- `terraform fmt -check` and `terraform validate` run in CI.
+- `tflint`, `checkov`, and `tfsec` block on findings of `error` or higher.
+- Deploy scripts: `set -euo pipefail`, `shellcheck` clean, idempotent.
+- `scripts/predeploy_check.py` runs before any apply.
+
+## Conventions
+
+- One module per concern under `deploy/terraform/` — no god-modules.
+- Variables typed and documented. No untyped strings.
+- Outputs minimal. Expose only what downstream modules need.
+- Naming: `<env>-<service>-<concern>` — e.g. `prod-golden-repo-cluster`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,74 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs]
+tags: [L9_TEMPLATE, docs, index]
+owner: platform
+status: active
+/L9_META -->
+
+# Documentation Index
+
+> Docs explain. Contracts enforce. When the two disagree, **contracts win** and docs get fixed.
+
+## Reading Order
+
+| # | Doc | When to Read |
+|---|---|---|
+| 1 | [`architecture/OVERVIEW.md`](architecture/OVERVIEW.md) | First day on the platform |
+| 2 | [`architecture/CONSTELLATION.md`](architecture/CONSTELLATION.md) | Before designing any new node |
+| 3 | [`architecture/ROUTING.md`](architecture/ROUTING.md) | Before touching any transport code |
+| 4 | [`boundaries/GATE.md`](boundaries/GATE.md), [`ORCHESTRATOR.md`](boundaries/ORCHESTRATOR.md), [`RUNTIME.md`](boundaries/RUNTIME.md) | Before contributing to any of the three |
+| 5 | [`contracts/TRANSPORT_PACKET.md`](contracts/TRANSPORT_PACKET.md) | Before writing any code that constructs or consumes a packet |
+| 6 | [`agents/CODING_GUIDE.md`](agents/CODING_GUIDE.md) | Every PR — this is the law for AI-authored code |
+| 7 | [`adr/`](adr/) | When proposing a non-trivial architectural change |
+| 8 | [`runbooks/`](runbooks/) | On-call, deploys, incidents |
+| 9 | [`security/`](security/), [`observability/`](observability/) | When the system fails or behaves oddly |
+
+## Layout
+
+```
+docs/
+├── README.md                          ← this index
+├── architecture/
+│   ├── OVERVIEW.md                    ← chassis vs engine, single ingress
+│   ├── CONSTELLATION.md               ← gate · orchestrator · runtime
+│   └── ROUTING.md                     ← node→gate→node invariant
+├── boundaries/
+│   ├── GATE.md                        ← what gate may and may not do
+│   ├── ORCHESTRATOR.md                ← workflow authority
+│   ├── RUNTIME.md                     ← execution-only node
+│   └── WHAT_LIVES_WHERE.md            ← canonical placement table
+├── contracts/                         ← human-readable companions to /contracts/
+│   ├── TRANSPORT_PACKET.md
+│   ├── ROUTING_POLICY.md
+│   ├── NODE_REGISTRATION.md
+│   ├── DELEGATION_PROTOCOL.md
+│   ├── PACKET_TYPE_REGISTRY.md
+│   └── BREAKING_CHANGE_POLICY.md
+├── agents/
+│   ├── CODING_GUIDE.md                ← rules every AI-authored PR follows
+│   ├── ORCHESTRATION_PATTERNS.md      ← recipes for common workflow shapes
+│   └── LIFECYCLE.md                   ← agent boot, registration, drain
+├── adr/
+│   ├── README.md                      ← ADR template + process
+│   ├── 0001-transport-packet-canonical.md
+│   └── 0002-gate-workflow-stateless.md
+├── runbooks/
+│   ├── DEPLOY.md                      ← Hetzner + Docker + Argo
+│   ├── INCIDENT.md                    ← severity, triage, war-room
+│   └── ON_CALL.md                     ← schedule, paging, escalation
+├── security/
+│   ├── THREAT_MODEL.md
+│   ├── SECRETS.md
+│   └── BOUNDARIES.md                  ← enforcement of L9 boundaries
+└── observability/
+    ├── TRACING.md                     ← W3C trace context, OTel propagation
+    ├── METRICS.md                     ← Prometheus, SLOs
+    └── LOGGING.md                     ← structlog JSON, redaction
+```
+
+## Companion `/contracts/`
+
+Every doc here has a counterpart contract under [`/contracts/`](../contracts/). The contract is the source of truth; the doc is the explanation.

--- a/docs/adr/0001-transport-packet-canonical.md
+++ b/docs/adr/0001-transport-packet-canonical.md
@@ -1,0 +1,87 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, adr]
+tags: [L9_TEMPLATE, adr, transport_packet]
+owner: platform
+status: active
+/L9_META -->
+
+# ADR-0001 — TransportPacket as Canonical Execution Contract
+
+- **Status:** Accepted
+- **Date:** 2026-04-26
+- **Deciders:** Platform team
+- **Tags:** transport, contracts, migration
+
+## Context
+
+L9 has historically used `PacketEnvelope` as its execution contract. As the platform grew to include Gate (transport authority), Orchestrator (workflow authority), and Runtime (execution authority), the envelope needed:
+
+- Mandatory transport-level fields (`provenance`, `hop_trace`, `delegation_chain`) that were optional or absent in `PacketEnvelope`.
+- A clear separation of `payload_hash` (semantic) and `transport_hash` (envelope integrity).
+- Append-only `hop_trace` as a tamper-evident routing journal.
+- Strict `lineage` reconstruction from any derived packet.
+
+`PacketEnvelope` was directionally correct but accumulated workflow-coupled fields and lacked the routing-level guarantees Gate requires.
+
+## Decision
+
+`TransportPacket` is the **only** canonical network execution contract for L9. `PacketEnvelope` is superseded.
+
+Specifically:
+
+- All ingress, egress, and inter-node traffic uses `TransportPacket`.
+- Schema: `contracts/transport/transport_packet.schema.json`.
+- Contract: `contracts/transport/transport_packet.contract.yaml`.
+- Migration: `contracts/transport/migration_from_packet_envelope.contract.yaml`.
+- Handler signature: `async def handler(packet: TransportPacket) -> TransportPacket`.
+- `transport_hash` excludes `hop_trace` to allow append-only hops without breaking envelope integrity.
+- `payload_hash` stands alone for semantic deduplication.
+
+## Consequences
+
+### Positive
+
+- Uniform validation surface across all nodes.
+- Hop-by-hop tamper evidence without breaking envelope hash.
+- Replay protection and idempotency become Gate-only enforcement.
+- Lineage is reconstructable from any derived packet.
+
+### Negative
+
+- One-time migration cost: every handler signature changes; every persisted packet store needs schema migration.
+- Dual-read window required for systems running mixed versions.
+
+### Neutral
+
+- `PacketEnvelope` artifacts (database tables, type aliases) remain only behind explicitly-scoped adapters during the migration window.
+
+## Alternatives Considered
+
+### Option A — Extend `PacketEnvelope` in place
+
+Add the missing fields, deprecate the old shape silently. Rejected: silent breaking changes are the worst-case L9 failure mode (see `BREAKING_CHANGE_POLICY.md`).
+
+### Option B — Multiple envelope types per concern
+
+Separate `RoutingPacket`, `WorkflowPacket`, `ExecutionPacket`. Rejected: Gate must remain workflow-stateless, which means it cannot dispatch on packet type semantics. One canonical packet keeps Gate's path single.
+
+## Migration Plan
+
+1. Land `TransportPacket` schema and contract (this ADR).
+2. Implement gate-client SDK that constructs `TransportPacket` correctly.
+3. Migrate Gate's `ExecuteService` to single-path `TransportPacket → TransportPacket`.
+4. Migrate every node's handler signature.
+5. Land dual-read adapter at `chassis/legacy/packet_envelope_adapter.py`.
+6. Roll out producers.
+7. Verify all consumers report `contract.version == 1.0.0`.
+8. Remove the adapter; mark `PacketEnvelope` contract `superseded`.
+
+## References
+
+- Contracts: `contracts/transport/`
+- Supersedes: legacy `contracts/packet_envelope_v1.yaml`
+- Related: ADR-0002 (Gate is workflow-stateless)
+- Boundary docs: `docs/boundaries/GATE.md`, `ORCHESTRATOR.md`, `RUNTIME.md`

--- a/docs/adr/0002-gate-workflow-stateless.md
+++ b/docs/adr/0002-gate-workflow-stateless.md
@@ -1,0 +1,78 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, adr]
+tags: [L9_TEMPLATE, adr, gate]
+owner: platform
+status: active
+/L9_META -->
+
+# ADR-0002 — Gate Is Workflow-Stateless
+
+- **Status:** Accepted
+- **Date:** 2026-04-26
+- **Deciders:** Platform team
+- **Tags:** gate, boundaries, authority
+
+## Context
+
+Earlier iterations of Gate had begun acquiring workflow-coupled responsibilities: a workflow classifier (`is_workflow()`), a workflow dispatcher, special handling for the orchestrator, and persistence of workflow DAG fragments for replay convenience.
+
+This drift introduced four problems:
+
+1. Gate's execution path branched on payload semantics, which the routing policy explicitly forbids.
+2. Replay and compensation logic lived in two places (Gate and Orchestrator), creating divergent semantics.
+3. Orchestrator became a "special" node, breaking the symmetry that allows Gate to dispatch any node uniformly.
+4. Boundary regression became cheap — adding workflow-aware code to Gate became a routine PR.
+
+## Decision
+
+Gate is **workflow-stateless**. It may hold operational state (rate limits, circuit breakers, idempotency dedup, replay guard, registry cache) but **no workflow state**.
+
+Concretely:
+
+- Gate's execute path is a single function: `validate → route → admit → dispatch → return`.
+- Gate has no `if is_workflow():` branches.
+- Gate does not import `orchestration/`, `schemas/workflow.py`, or `config/workflows.yaml`. CI fails the build if it does.
+- Orchestrator registers as a normal node. Gate has no code that distinguishes it.
+- All workflow authority — decomposition, branching, retry semantics, replay semantics, compensation semantics — lives in the Orchestrator.
+- Mission kernel (`load_or_create_mission_state`, `checkpoint`, `restore`, `branch`, `merge`, `aggregate`, `decide_next_step`) is exclusively owned by the Orchestrator.
+
+## Consequences
+
+### Positive
+
+- Gate's path is testable in isolation; no payload-semantic dependencies.
+- Workflow logic has exactly one home.
+- Orchestrator can be added, removed, replaced, or scaled independently of Gate.
+- Boundary regression is detected at CI, not at runtime.
+
+### Negative
+
+- Some convenience features previously in Gate (e.g., implicit retry on transient failures with workflow awareness) move to Orchestrator and become explicit.
+- Orchestrator must be highly available — but this was true regardless.
+
+### Neutral
+
+- Operational replay protection (transport-level packet_id dedup) stays in Gate. Semantic replay (workflow-level) is Orchestrator's.
+
+## Alternatives Considered
+
+### Option A — Allow Gate to hold workflow DAG fragments for replay efficiency
+
+Rejected: turns Gate into a co-owner of workflow truth. Two co-owners produce divergent state.
+
+### Option B — Combine Gate and Orchestrator into a single "control plane" service
+
+Rejected: collapses the routing-vs-workflow boundary. Independent scaling, deployment, and failure isolation are lost.
+
+## Migration Plan
+
+This ADR documents a state to be enforced going forward; specific migration steps are in [`contracts/transport/migration_from_packet_envelope.contract.yaml`](../../contracts/transport/migration_from_packet_envelope.contract.yaml) Wave 1 (1F/1G/1H — delete `orchestration/`, `schemas/workflow.py`, `config/workflows.yaml` from Gate).
+
+## References
+
+- Contracts: `contracts/gate/gate.contract.yaml`, `contracts/orchestrator/orchestrator.contract.yaml`
+- Boundary doc: `docs/boundaries/GATE.md`
+- Related: ADR-0001 (TransportPacket canonical)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,50 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, adr]
+tags: [L9_TEMPLATE, adr]
+owner: platform
+status: active
+/L9_META -->
+
+# Architecture Decision Records
+
+> Every non-trivial architectural decision is recorded here. ADRs are immutable once accepted — corrections happen in a new ADR that supersedes the old one.
+
+## Process
+
+1. Copy `TEMPLATE.md` to `NNNN-{slug}.md` where `NNNN` is the next four-digit number.
+2. Fill in Context, Decision, Consequences, Alternatives, and References.
+3. Open a PR. Reviewers must include at least one platform owner.
+4. On merge, the ADR is `Accepted`.
+5. To change a decision, open a new ADR with `Status: Supersedes NNNN`.
+
+## Statuses
+
+| Status | Meaning |
+|---|---|
+| Proposed | Open PR, not yet merged |
+| Accepted | Current canonical decision |
+| Superseded by NNNN | Decision is no longer in force; see linked ADR |
+| Deprecated | Decision is no longer applicable, no replacement |
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| 0001 | TransportPacket as canonical execution contract | Accepted |
+| 0002 | Gate is workflow-stateless | Accepted |
+
+## When to Open an ADR
+
+- Choosing a new transport, persistence, or auth mechanism
+- Changing a contract (any breaking change requires an ADR)
+- Adding a new authority or splitting an existing one
+- Adopting or removing a major dependency
+- Changing the boundary between Gate, Orchestrator, or Runtime
+- Anything that future maintainers would ask "why?" about
+
+## Template
+
+See [`TEMPLATE.md`](TEMPLATE.md).

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,61 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, adr]
+tags: [L9_TEMPLATE, adr, template]
+owner: platform
+status: template
+/L9_META -->
+
+# ADR-NNNN — {Title}
+
+- **Status:** Proposed | Accepted | Superseded by ADR-MMMM | Deprecated
+- **Date:** YYYY-MM-DD
+- **Deciders:** {names / teams}
+- **Tags:** {area, e.g., transport, gate, security}
+
+## Context
+
+What problem are we solving? What forces are at play (technical, business, organizational)? What constraints apply?
+
+## Decision
+
+The decision in one paragraph, then a bulleted list of specifics.
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+### Neutral / Trade-offs
+
+- ...
+
+## Alternatives Considered
+
+### Option A — {name}
+
+Description, pros, cons, why rejected.
+
+### Option B — {name}
+
+Description, pros, cons, why rejected.
+
+## Migration Plan (if breaking)
+
+- Step 1
+- Step 2
+- Rollback procedure
+
+## References
+
+- Contracts touched: `contracts/...`
+- Docs touched: `docs/...`
+- Related ADRs: ADR-NNNN
+- External: {RFCs, papers, vendor docs}

--- a/docs/agents/CODING_GUIDE.md
+++ b/docs/agents/CODING_GUIDE.md
@@ -1,0 +1,154 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, agents]
+tags: [L9_TEMPLATE, agents, coding_guide]
+owner: platform
+status: active
+/L9_META -->
+
+# Agent Coding Guide
+
+> Canonical law for AI-authored code in L9 repos. Every PR — human or agent — is reviewed against this guide.
+
+## 1. System Identity
+
+| Property | Value |
+|---|---|
+| Repo role | L9 Constellation node template |
+| Ingress | `POST /v1/execute` and `GET /v1/health` only |
+| Egress | `TransportPacket` via gate-client SDK only |
+| Node-name format | `{domain}-engine` or `{domain}-{function}` — lowercase, hyphenated |
+| Nature | A node inside the Constellation, never a standalone app |
+
+## 2. Immutable Laws
+
+### LAW-01 — Single Ingress
+- Only `POST /v1/execute` and `GET /v1/health`. No other HTTP routes, websockets, gRPC, or alternate surfaces.
+- Engines must NEVER import FastAPI, Starlette, or any HTTP library.
+
+### LAW-02 — Handler Interface
+- Engines expose handlers only:
+
+  ```python
+  async def handle_<action>(packet: TransportPacket) -> TransportPacket
+  ```
+
+- Register in `engine/handlers.py` via `chassis.router.register_handler("<action>", handle_<action>)`.
+- `handlers.py` is the **only** file that imports chassis modules.
+
+### LAW-03 — Tenant Isolation
+- Tenant is resolved by the chassis. Engines receive it as a string. Never resolve tenant in engine code. No cross-tenant reads or writes.
+
+### LAW-04 — Observability Is Inherited
+- Engines never configure structlog, Prometheus, or logging handlers. Use `structlog.get_logger(__name__)` and nothing else.
+
+### LAW-05 — Infrastructure Is Template
+- Engines never create Dockerfiles, compose files, CI pipelines, or Terraform modules. Add engine env vars to `.env.template` only.
+
+### LAW-06 — TransportPacket Is The Only Container
+- Every inter-service payload is a `TransportPacket`. `inflate_ingress()` at boundary entry, `deflate_egress()` at boundary exit. Engine code between boundaries works with typed Pydantic — never raw envelopes.
+
+### LAW-07 — Immutability + Content Hash
+- `TransportPacket` is frozen. Mutations create new packets via `.derive()`. `transport_hash` and `payload_hash` are sha256. Idempotency uses `header.idempotency_key`.
+
+### LAW-08 — Lineage + Audit
+- Every derived packet sets `parent_id`, `root_id`, increments `generation`. `hop_trace` is append-only. `delegation_chain` carries scoped authorization.
+
+### LAW-09 — Cypher / SQL Injection Prevention
+- All Neo4j labels and relationship types pass `sanitize_label()` before interpolation (regex `^[A-Za-z_][A-Za-z0-9_]*$`).
+- VALUES are always parameterized (`$batch`, `$query`).
+- Never `eval()`, `exec()`, `pickle.load()`, or `yaml.load()` without `SafeLoader`.
+
+### LAW-10 — Prohibited Factors
+- `race`, `ethnicity`, `religion`, `gender`, `age`, `disability`, `familial_status`, `national_origin`, `marital_status`, `genetic_information` are blocked at compile-time during gate validation. Violations fail compilation, not runtime.
+
+### LAW-11 — PII Handling
+- PII fields declared in `domain.compliance.pii.fields`. Modes: `hash` · `encrypt` · `redact` · `tokenize`. Engine never logs PII values.
+
+### LAW-12 — Domain Spec Is Source of Truth
+- Matching behavior comes from `domains/<id>/spec.yaml`. `DomainPackLoader` reads YAML → Pydantic. Downstream consumes `DomainSpec` — never raw YAML, never raw dicts.
+
+### LAW-13 — Gate-Then-Score Architecture
+- Matching is two-phase: gates (hard filter) → scoring (soft rank). All gate logic compiles to Cypher `WHERE`; all scoring to a single `WITH/ORDER BY`. Zero post-filtering in Python.
+
+### LAW-14 — Null Semantics Are Deterministic
+- Every gate declares `null_behavior: pass | fail`. The compiler — not the caller — applies the rule.
+
+### LAW-15 — Bidirectional Matching
+- Gates with `invertible: true` swap `field` ↔ `query_param` when match direction reverses. Gate implementations are direction-unaware; the compiler handles it.
+
+### LAW-16 — File Structure Is Fixed
+- Top-level engine directories are pre-defined. New top-level directories require architectural review.
+
+### LAW-17 — Test Requirements
+- Unit tests cover gate compilation, scoring math, parameter resolution, null semantics per gate.
+- Integration tests use `testcontainers-neo4j` — never mock the Neo4j driver.
+- Compliance tests verify prohibited factors are blocked at compile time.
+- Performance: <200ms p95 match latency.
+
+### LAW-18 — L9_META On Every File
+- Every tracked file carries an L9_META header (schema version 1) — `l9_schema · origin · engine · layer · tags · owner · status`.
+- Format varies by filetype. Injected by `tools/l9_meta_injector.py`, never manually.
+
+### LAW-19 — Declarative GDS Jobs
+- Graph Data Science algorithms are declared in `spec.gds_jobs`. Schedule type: `cron | manual`. Scheduler reads spec — no hardcoded calls.
+
+### LAW-20 — KGE Embeddings (CompoundE3D)
+- Default 256-dim. Beam search width=10, depth=3. Ensemble: weighted_average | rank_aggregation | mixture_of_experts. Embeddings are domain-specific, never shared cross-tenant.
+
+## 3. Code Style
+
+- **Language** Python 3.12+, `async/await` for all I/O.
+- **Type hints** Every signature, every class attribute, every ambiguous variable.
+- **Models** Pydantic v2 `BaseModel(frozen=True)` for structured data.
+- **Formatter** `ruff format` (88-char line length).
+- **Linter** `ruff check` + `mypy --strict engine/`.
+- **Logging** `structlog.get_logger(__name__)`. Include `tenant`, `trace_id`, `action` in context.
+- **Naming** `snake_case` everywhere. No Pydantic `Field(alias=...)`. YAML keys identical to Python field names.
+- **Exceptions** Always assign message to a variable first to avoid EM101/EM102.
+- **Nullable params** `def f(x: str | None = None)` — never implicit Optional.
+- **Datetime** Always timezone-aware: `datetime.now(tz=UTC)`.
+- **Magic values** Named constants in `engine/`; literals OK in `tests/`.
+
+## 4. Banned Patterns (CI fails the build)
+
+| ID | Pattern | Contract |
+|---|---|---|
+| SEC-001 | f-string Cypher MATCH without `sanitize_label()` | LAW-09 |
+| SEC-002 | `eval()` | LAW-09 |
+| SEC-003 | `exec()` | LAW-09 |
+| SEC-004 | f-string `LIMIT` interpolation | LAW-09 |
+| SEC-005 | f-string SQL interpolation | LAW-09 |
+| SEC-006 | `pickle.load(s)` | LAW-09 |
+| SEC-007 | `yaml.load()` without `SafeLoader` | LAW-09 |
+| ARCH-001 | `from fastapi import` in `engine/` | LAW-01 |
+| ARCH-002 | `from starlette import` in `engine/` | LAW-01 |
+| ARCH-003 | `import uvicorn` in `engine/` | LAW-01 |
+| DEL-001 | `httpx.{post,get,...}` in `engine/` | LAW-08 |
+| DEL-002 | `requests.{post,get,...}` in `engine/` | LAW-08 |
+| MEM-001 | Direct `INSERT INTO packetstore` in `engine/` | LAW-07 |
+| STUB-001 | `raise NotImplementedError` outside `tests/` | zero-stub |
+| OBS-001 | `structlog.configure()` in `engine/` | LAW-04 |
+| OBS-002 | `logging.basicConfig()` in `engine/` | LAW-04 |
+| NAME-001 | Pydantic `Field(alias=...)` | naming |
+| PKT-001 | Uppercase `packet_type` value | LAW-06 |
+
+## 5. Enforcement Pipeline
+
+1. **Pre-commit** — `ruff` · `mypy --strict` · `tools/contract_scanner.py` · `tools/verify_contracts.py`
+2. **CI Lint** — same as pre-commit, repo-wide
+3. **CI Tests** — pytest (unit · integration · compliance · performance)
+4. **CI Audit** — `tools/verify_contracts.py` (all contracts present and wired)
+5. **LLM Review** — CodeRabbit · Qodo · Claude (contract-aware instructions)
+
+Branch protection: all 5 status checks required. No bypass.
+
+## 6. Reference Reading
+
+- [`docs/architecture/OVERVIEW.md`](../architecture/OVERVIEW.md)
+- [`docs/contracts/TRANSPORT_PACKET.md`](../contracts/TRANSPORT_PACKET.md)
+- [`docs/boundaries/`](../boundaries/)
+- [`docs/agents/ORCHESTRATION_PATTERNS.md`](ORCHESTRATION_PATTERNS.md)
+- [`docs/agents/LIFECYCLE.md`](LIFECYCLE.md)

--- a/docs/agents/LIFECYCLE.md
+++ b/docs/agents/LIFECYCLE.md
@@ -1,0 +1,78 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, agents]
+tags: [L9_TEMPLATE, agents, lifecycle]
+owner: platform
+status: active
+/L9_META -->
+
+# Agent Lifecycle
+
+> Boot, registration, drain, shutdown — for every node type.
+
+## Boot Sequence
+
+1. **Typed config load** — `chassis/settings.py` reads env, validates with pydantic-settings. Fail fast on missing required env.
+2. **Preflight checks** — `scripts/predeploy_check.py` runs (Neo4j reachability, Redis ping, dependent services).
+3. **Runtime store init** — connection pools, model loaders, KGE embeddings, semantic retriever warmup.
+4. **Handler registration** — `engine/handlers.py` registers every action handler with the chassis router.
+5. **Node registration** — POST to Gate `/v1/admin/register` with the node's declared `supported_actions`.
+6. **Health probe activation** — `/v1/health` returns `live=true`.
+7. **Readiness flip** — `/v1/readiness` returns `ready=true` only after steps 1–5 succeed. Gate begins routing traffic on this signal.
+
+`/v1/readiness` returning `false` is the only way Gate knows a node is not yet eligible for traffic.
+
+## Steady State
+
+- Handlers run under chassis middleware: auth, tenant resolution, packet inflation, trace propagation, structured logging, metrics.
+- Each handler:
+  1. Validates the inbound packet against `transport_packet.schema.json`.
+  2. Validates the payload against the action's payload schema.
+  3. Executes within the resource budget declared in `engine/execution/resource_budget.py`.
+  4. Returns a derived `TransportPacket` with `packet_type=response`.
+  5. Appends one entry to `hop_trace`.
+
+## Drain (Graceful Shutdown)
+
+1. Drain signal received (SIGTERM, autoscaler, deploy).
+2. `/v1/readiness` returns `ready=false` immediately. Gate stops routing new packets to this node.
+3. In-flight handlers continue to completion within `drain_timeout_ms` (default 30s).
+4. Background work (consolidation, GDS, scheduled jobs) is checkpointed and stopped.
+5. Connection pools closed; semantic retriever flushed; episodic store synced.
+6. Process exits 0.
+
+## Hard Shutdown
+
+If `drain_timeout_ms` elapses with in-flight handlers, the process exits 1. The orchestrator's replay mechanism resumes any incomplete workflow steps using checkpoint state.
+
+## Failure Modes
+
+| Symptom | Likely Cause | Action |
+|---|---|---|
+| `/v1/readiness` stuck `false` | Preflight check failing | Inspect startup logs; check dependent service reachability |
+| Gate marks node `unhealthy` | Health probe failing | Check `chassis/health.py` adapter status; check resource exhaustion |
+| Handlers timeout | Resource budget too low or external dep slow | Tune `resource_budget`; add circuit breaker upstream |
+| Memory growth | Leaking caches in runtime state | Check `state_manager.py` bounded-state guarantees |
+| Trace gaps | Detached async work without trace context | Audit `LAW-08` violations; ensure SDK propagation |
+
+## Registration Lifecycle Detail
+
+```
+boot ─→ POST /v1/admin/register
+            │
+            ├── 201 Created           → node visible to Gate, but not active
+            ├── 200 OK (overwrite)    → existing entry replaced
+            └── 409 Conflict          → registration rejected (overwrite=false)
+
+health ─→ GET /v1/health
+            │
+            └── adapter healthy → Gate marks node `active`
+
+shutdown ─→ readiness=false
+            │
+            └── Gate marks node `draining`, then `inactive`
+```
+
+Gate is authoritative for activation and health state. Registration is a declaration, not a guarantee.

--- a/docs/agents/ORCHESTRATION_PATTERNS.md
+++ b/docs/agents/ORCHESTRATION_PATTERNS.md
@@ -1,0 +1,118 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, agents]
+tags: [L9_TEMPLATE, agents, orchestration_patterns]
+owner: platform
+status: active
+/L9_META -->
+
+# Orchestration Patterns
+
+> Canonical recipes for common workflow shapes. Every pattern below routes every sub-step through Gate.
+
+## Pattern 1 — Single Action
+
+A single action handler runs to completion in one runtime node.
+
+```
+client → gate → runtime → gate → client
+```
+
+Use when: the work is a single bounded capability (e.g., `match`, `enrich`, `score`).
+
+## Pattern 2 — Sequential Workflow
+
+Decompose a goal into ordered steps. Orchestrator emits each sub-task via the gate-client.
+
+```
+client → gate → orchestrator
+                    │
+                    ├── gate → runtime_a → gate → orchestrator
+                    ├── gate → runtime_b → gate → orchestrator
+                    └── gate → runtime_c → gate → orchestrator
+                                                       │
+                                                       ▼
+                                                client (terminal)
+```
+
+Use when: the steps depend on each other and order matters.
+
+## Pattern 3 — Fan-Out / Fan-In
+
+Orchestrator dispatches N parallel sub-tasks and merges results.
+
+```
+                ┌─ gate → runtime_x ─┐
+orchestrator ───┼─ gate → runtime_y ─┤── orchestrator (merge)
+                └─ gate → runtime_z ─┘
+```
+
+Mission kernel handles fan-in semantics: `branch`, `merge`, `aggregate`, `decide_next_step`.
+
+## Pattern 4 — Conditional Branch
+
+Orchestrator's `condition_evaluator` decides the next step based on prior results.
+
+```
+orchestrator ─→ gate → runtime_classifier ─→ orchestrator
+                                                  │
+                                  ┌───────────────┴───────────────┐
+                                  ▼                               ▼
+                          gate → runtime_path_a         gate → runtime_path_b
+```
+
+The conditional logic lives in the orchestrator's `engine/condition_evaluator.py`. Runtime nodes know nothing about the branch.
+
+## Pattern 5 — Saga (Compensating Transaction)
+
+A multi-step workflow with compensation on failure.
+
+```
+orchestrator ─→ step_1 (commit)
+              ─→ step_2 (commit)
+              ─→ step_3 (fail) ──→ saga_manager
+                                      │
+                                      ├── compensate(step_2)
+                                      └── compensate(step_1)
+```
+
+Compensation steps are themselves `TransportPacket` with `packet_type: compensation` and route through Gate like any other step.
+
+## Pattern 6 — Replay
+
+Orchestrator replays a workflow from a checkpoint.
+
+```
+orchestrator.load(workflow_id, checkpoint=N)
+  └── re-emit step_N+1 with packet_type=replay_request
+        └── runtime executes → packet_type=replay_response
+              └── orchestrator updates state
+```
+
+Replay never bypasses Gate. Replay protection at the transport level uses `header.packet_id`; semantic replay logic lives in the orchestrator.
+
+## Pattern 7 — Long-Running with Status
+
+Orchestrator returns a synthetic `accepted` response immediately, then progresses asynchronously. Client polls a status action.
+
+```
+client → gate → orchestrator (returns "accepted" with workflow_id)
+                    │
+                    ▼ (background)
+                  gate → runtime_step_1 ...
+
+client → gate → orchestrator(action="get_status", workflow_id=...) → "running" | "complete" | "failed"
+```
+
+Status is `action`-addressed — never a separate HTTP route.
+
+## Anti-Patterns
+
+- ❌ Orchestrator calling Runtime directly (bypasses Gate)
+- ❌ Runtime emitting follow-up packets without orchestrator authority
+- ❌ Branching logic inside Gate ("`if is_workflow():`")
+- ❌ Workflow state inside Runtime
+- ❌ A separate `/v1/orchestrate` ingress
+- ❌ Detached async traces — every span chain stays under one root `trace_id` per workflow hop

--- a/docs/architecture/CONSTELLATION.md
+++ b/docs/architecture/CONSTELLATION.md
@@ -1,0 +1,95 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, architecture]
+tags: [L9_TEMPLATE, architecture, constellation]
+owner: platform
+status: active
+/L9_META -->
+
+# Constellation Topology
+
+The Constellation is the runtime graph: **Gate** at the center, **Orchestrator** and **Runtime** nodes registered as peers. Gate sees no difference between them — both are nodes addressed by `action`.
+
+## Logical Diagram
+
+```
+                External Request
+                       │
+                       ▼
+              ┌────────────────┐
+              │      GATE      │  WORKFLOW-STATELESS
+              │                │  OPERATIONALLY STATEFUL
+              │  1. Parse      │  raw JSON → TransportPacket
+              │  2. Validate   │  IngressValidator
+              │  3. Route      │  RoutingPolicy → NodeRegistry
+              │  4. Admit      │  CB · rate limit · load shed
+              │  5. Dispatch   │  HTTP/NATS/Kafka adapter
+              │  6. Return     │  response packet
+              └───────┬────────┘
+                      │
+            ┌─────────┴──────────┐
+            ▼                    ▼
+   ┌─────────────────┐  ┌────────────────┐
+   │  ORCHESTRATOR   │  │    RUNTIME     │
+   │   (stateful)    │  │ (bounded state)│
+   │                 │  │                │
+   │  Decomposes     │  │  Executes      │
+   │  Sequences      │  │  Isolates      │
+   │  Branches       │  │  Budgets       │
+   │  Tracks DAGs    │  │  Scales        │
+   │  Compensates    │  │                │
+   └────────┬────────┘  └────────────────┘
+            │
+            │ Sub-tasks route BACK through Gate
+            │ via SDK transport boundary (gate-client)
+            ▼
+         ┌──────┐
+         │ GATE │ → routes to Runtime (or another Orchestrator)
+         └──────┘
+```
+
+## Module Placement
+
+### Gate (`constellation_gate/`)
+
+```
+boundary/      ingress_validator · routing_policy · context_injector · transport_codec · response_factory · failure_factory
+resilience/    circuit_breaker · rate_limiter · load_shedding · backpressure · admission_controller · replay_guard · idempotency
+routing/       node_registry · dispatcher
+schemas/       packet · registry
+runtime/       lifecycle · http_client · health
+config/        settings · node_registry.yaml · priorities.yaml
+api/           main · dependencies
+```
+
+### Orchestrator (`constellation_orchestrator/`)
+
+```
+engine/        orchestration_engine · condition_evaluator · decomposability_classifier · payload_transformer · deadline_propagator
+compensation/  saga_manager · checkpoint_store
+schemas/       workflow
+config/        workflows.yaml · orchestrator_settings
+api/           main · transport_adapter
+```
+
+### Runtime (`constellation_runtime/`)
+
+```
+execution/     agent_executor · resource_budget · state_manager
+memory/        semantic_retriever · episodic_store
+scaling/       autoscaler · pool_manager
+```
+
+## Registration
+
+Every node — including Orchestrator — registers via `POST /v1/admin/register` with the same payload shape (see [`contracts/registration/node_registration.contract.yaml`](../../contracts/registration/node_registration.contract.yaml)).
+
+## Boundary Enforcement
+
+- Gate **MUST NOT** import `orchestration/`, `schemas/workflow.py`, or `config/workflows.yaml`. CI fails the build if it does.
+- Runtime **MUST NOT** import other runtime nodes. Workers don't know peer URLs.
+- Orchestrator **MUST NOT** dispatch except via the gate-client SDK boundary.
+
+See [`docs/boundaries/`](../boundaries/) for the per-authority enforcement details.

--- a/docs/architecture/OVERVIEW.md
+++ b/docs/architecture/OVERVIEW.md
@@ -1,0 +1,76 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, architecture]
+tags: [L9_TEMPLATE, architecture, overview]
+owner: platform
+status: active
+/L9_META -->
+
+# L9 Architecture Overview
+
+> Every L9 product is a standalone engine that plugs into a universal chassis. The chassis is reusable. The engine is what you build. Nothing else.
+
+## Core Principle
+
+- **One ingress** — `POST /v1/execute` is the only mutation endpoint. `GET /v1/health` is the only other route.
+- **One contract** — `TransportPacket` is the canonical execution envelope. Nothing else crosses node boundaries.
+- **One topology** — every follow-up packet returns through Gate. Workers never call workers.
+
+## The Three Authorities
+
+| Authority | Role | Workflow State | Owns |
+|---|---|---|---|
+| **Gate** | Transport authority | None | Validation · routing · admission · dispatch |
+| **Orchestrator** | Workflow authority | Durable | Decomposition · sequencing · replay · compensation |
+| **Runtime** | Execution authority | Bounded | Capability execution · resource budgets · local caches |
+
+See:
+- [`boundaries/GATE.md`](../boundaries/GATE.md)
+- [`boundaries/ORCHESTRATOR.md`](../boundaries/ORCHESTRATOR.md)
+- [`boundaries/RUNTIME.md`](../boundaries/RUNTIME.md)
+
+## The Universal Path
+
+```
+Client ──▶ Gate ──▶ Worker (Runtime or Orchestrator)
+                       │
+                       ▼
+                     Gate ──▶ Worker  (sub-steps)
+                       │
+                       ▼
+                     Gate ──▶ Client
+```
+
+Every arrow is a `TransportPacket`. Every transition is observable, idempotent, and replayable.
+
+## What the Chassis Provides (Do Not Rebuild)
+
+- `chassis/auth.py` — SHA-256 API key verification
+- `chassis/router.py` — action → handler mapping
+- `chassis/tenant.py` — 5-method resolution (header → subdomain → key prefix → envelope → default)
+- `chassis/middleware.py` — structured logging, trace propagation, metrics
+- `chassis/health.py` — `/v1/health`, `/v1/readiness`, `/metrics`
+- `chassis/orchestrator.py` — gate-client transport boundary
+
+## What Each Engine Builds
+
+- Action handlers (`handle_<action>(packet: TransportPacket) -> TransportPacket`)
+- Domain spec (`domains/<id>/spec.yaml`)
+- Capability implementations under `engine/`
+- Tests under `tests/{unit,integration,contracts,compliance}`
+
+Nothing else. No FastAPI imports in `engine/`. No Dockerfile authored per-repo. No custom transport.
+
+## Why This Design
+
+| Problem | L9 Answer |
+|---|---|
+| Per-route auth bugs | One auth check at the chassis, ever |
+| Inconsistent observability | Trace propagation owned by SDK + transport |
+| Workflow logic leaking everywhere | Workflow authority confined to Orchestrator |
+| Direct service coupling | Workers don't know peer URLs — only Gate does |
+| Replay/idempotency drift | One canonical packet, one enforcement point (Gate) |
+
+See [`CONSTELLATION.md`](CONSTELLATION.md) for module-level placement and [`ROUTING.md`](ROUTING.md) for the routing invariant.

--- a/docs/architecture/ROUTING.md
+++ b/docs/architecture/ROUTING.md
@@ -1,0 +1,68 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, architecture]
+tags: [L9_TEMPLATE, routing]
+owner: platform
+status: active
+/L9_META -->
+
+# Routing — The Single Invariant
+
+> **All node-originated follow-up traffic returns to Gate.**
+> Workers never call workers. Orchestrator never calls Runtime directly.
+
+Source contract: [`contracts/routing/routing_policy.contract.yaml`](../../contracts/routing/routing_policy.contract.yaml)
+
+## Allowed Patterns
+
+- `client → gate`
+- `node → gate`
+- `gate → worker`
+
+## Forbidden Patterns
+
+- `node_a → node_b`
+- `orchestrator → worker (direct)`
+- `worker → worker`
+
+## Why
+
+- **Uniform observability** — every hop crosses Gate, so every hop is traced, metered, and logged identically.
+- **Uniform admission** — circuit breakers, rate limits, load shedding apply once and apply consistently.
+- **Decoupled deployment** — workers don't know peer URLs; nodes can be added, removed, or relocated without touching workers.
+- **Replay correctness** — a single transport authority is the only place where idempotency and replay protection need to be enforced.
+
+## Selection Algorithm
+
+1. Lookup `header.action` in NodeRegistry.
+2. Filter by `health == active`.
+3. Filter by priority class eligibility.
+4. Apply admission controller (CB → rate limit → load shed).
+5. Dispatch via configured transport adapter.
+
+## Failure Modes
+
+| Condition | Failure Packet `reason` |
+|---|---|
+| Action not registered | `UNROUTABLE` |
+| No healthy node | `NODE_UNAVAILABLE` |
+| Admission denied | `ADMISSION_DENIED` |
+
+## Provenance Rules
+
+| Originator | `provenance.origin_kind` | `address.source_node` | `address.destination_node` |
+|---|---|---|---|
+| External client | `client` | client identifier | `gate` |
+| Node follow-up | `node` | local node | `gate` |
+| Gate dispatch | `gate` | `gate` | resolved worker |
+
+A packet whose origin is `node` but whose destination is anything other than `gate` is a contract violation and is rejected at the gate-client boundary.
+
+## Enforcement Points
+
+- `sdk_gate_client` — packets are constructed correctly or not at all.
+- `gate_ingress_validator` — rejects malformed provenance.
+- `gate_routing_policy_validator` — rejects forbidden patterns.
+- `tests/contracts/test_no_direct_node_calls.py` — static scan of imports/calls.

--- a/docs/boundaries/GATE.md
+++ b/docs/boundaries/GATE.md
@@ -1,0 +1,91 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, boundaries]
+tags: [L9_TEMPLATE, gate, boundaries]
+owner: platform
+status: active
+/L9_META -->
+
+# Gate Boundary
+
+Source contract: [`contracts/gate/gate.contract.yaml`](../../contracts/gate/gate.contract.yaml)
+
+## Identity
+
+Gate is the **workflow-stateless transport authority**. One path. One job. No semantic decisions.
+
+## Single Execute Path
+
+```python
+async def execute(packet: TransportPacket) -> TransportPacket:
+    validate(packet)
+    node = route(packet.header.action)
+    await admit(node)
+    response = await dispatch(node, packet)
+    return build_response(response)
+```
+
+No `if is_workflow():`. No branch on node type. No payload inspection for semantic meaning.
+
+## Allowed Decisions
+
+- **Routing** — action → node selection via NodeRegistry.
+- **Admission** — circuit breaker, rate limit, load shedding, backpressure.
+- **Resilience** — replay guard, idempotency cache.
+
+## Forbidden Decisions
+
+- Workflow branching, decomposition, retry semantics, replay semantics, compensation semantics.
+
+## State Model
+
+| Allowed (operational) | Forbidden (workflow) |
+|---|---|
+| Node registry cache | Workflow DAGs |
+| Circuit breaker state | Step state |
+| Rate limiter state | Replay state |
+| Load shedding signals | Compensation state |
+| Idempotency dedup store | Mission state |
+| Replay guard | Semantic retry state |
+
+All operational state must be **bounded · non-authoritative · discardable without semantic loss**.
+
+## Module Layout (must exist)
+
+```
+boundary/      ingress_validator.py routing_policy.py context_injector.py
+               transport_codec.py response_factory.py failure_factory.py
+resilience/    circuit_breaker.py rate_limiter.py load_shedding.py
+               backpressure.py admission_controller.py replay_guard.py idempotency.py
+routing/       node_registry.py dispatcher.py
+schemas/       packet.py registry.py
+runtime/       lifecycle.py http_client.py health.py
+config/        settings.py node_registry.yaml priorities.yaml
+api/           main.py dependencies.py
+```
+
+## Module Layout (must NOT exist in Gate)
+
+- `orchestration/`
+- `schemas/workflow.py`
+- `config/workflows.yaml`
+- `boundary/workflow_dispatcher.py`
+- Any workflow classifier or semantic replay/compensation factory
+
+## CI Build Fails If
+
+- Workflow logic appears in Gate
+- `PacketEnvelope` imports exist
+- Direct node-to-node calls exist
+- Raw HTTP posts to `/v1/execute` bypass the gate-client SDK
+- Packet mutation occurs without `derive()`
+- Routing policy is bypassed
+- Handler signature is not `TransportPacket → TransportPacket`
+- TransportPacket schema validation is missing at gate ingress
+- A registered node has empty `supported_actions`
+
+## Orchestrator Treatment
+
+Orchestrator is a **normal node** to Gate. Gate must not have any code that distinguishes it. Registration uses the same shape as any other node.

--- a/docs/boundaries/ORCHESTRATOR.md
+++ b/docs/boundaries/ORCHESTRATOR.md
@@ -1,0 +1,91 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, boundaries]
+tags: [L9_TEMPLATE, orchestrator, boundaries]
+owner: platform
+status: active
+/L9_META -->
+
+# Orchestrator Boundary
+
+Source contract: [`contracts/orchestrator/orchestrator.contract.yaml`](../../contracts/orchestrator/orchestrator.contract.yaml)
+
+## Identity
+
+Orchestrator is the **workflow authority**. From Gate's perspective it is a normal node — addressed by `action`, dispatched like any other. From the system's perspective it is the only place where workflow meaning lives.
+
+## Authority Model
+
+Orchestrator owns:
+
+- Decomposition of tasks into steps
+- Sequencing of step execution
+- Branching logic on workflow state
+- Retry, replay, and compensation semantics
+- Result aggregation
+- Terminal outcome production
+
+Orchestrator must not:
+
+- Route packets directly
+- Bypass Gate
+- Own transport logic
+- Maintain a private node registry
+- Perform admission control
+
+## State Model
+
+Orchestrator is **authoritatively stateful**. All workflow state is durable, replayable, and auditable.
+
+Owned state:
+
+- workflow_dag · step_state · execution_history
+- replay_state · compensation_state · terminal_outcomes
+- mission_state · checkpoint_state
+
+## Execution Loop
+
+```
+1. receive transport packet
+2. load or create workflow state
+3. evaluate next step(s)
+4. emit subtask transport packet via gate-client
+5. update state
+6. repeat until terminal
+```
+
+All sub-task dispatch goes through Gate. No direct calls to runtime nodes.
+
+## Mission Kernel
+
+The mission kernel — `load_or_create_mission_state`, `checkpoint`, `restore`, `branch`, `merge`, `aggregate`, `decide_next_step` — is **exclusively** owned by the Orchestrator. It must not appear in Gate, in runtime nodes, or in the gate-client.
+
+## Module Layout
+
+```
+engine/         orchestration_engine.py condition_evaluator.py
+                decomposability_classifier.py payload_transformer.py
+                deadline_propagator.py
+compensation/   saga_manager.py checkpoint_store.py
+schemas/        workflow.py
+config/         workflows.yaml orchestrator_settings.py
+api/            main.py transport_adapter.py
+```
+
+## Forbidden
+
+- Direct runtime node calls
+- Custom transport routing logic
+- Private node registry
+- Admission control
+- Special semantic ingress like `/v1/orchestrate` as architectural identity
+
+The Orchestrator's HTTP surface is `POST /v1/execute` and `GET /v1/health`. Period.
+
+## Integration Rules
+
+- All outbound packets go through Gate via the SDK transport layer.
+- Preserve `trace_id` and `lineage` across all derived packets.
+- Never fork traces arbitrarily — one workflow hop, one trace.

--- a/docs/boundaries/RUNTIME.md
+++ b/docs/boundaries/RUNTIME.md
@@ -1,0 +1,86 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, boundaries]
+tags: [L9_TEMPLATE, runtime, boundaries]
+owner: platform
+status: active
+/L9_META -->
+
+# Runtime Boundary
+
+Source contract: [`contracts/runtime/runtime.contract.yaml`](../../contracts/runtime/runtime.contract.yaml)
+
+## Identity
+
+Runtime is the **execution-only authority**. It receives a `TransportPacket`, executes a single capability, returns a `TransportPacket`. Nothing more.
+
+## Handler Contract
+
+```python
+async def handler(packet: TransportPacket) -> TransportPacket: ...
+```
+
+Every runtime handler accepts a `TransportPacket` and returns a `TransportPacket`. No raw dicts, no untyped envelopes, no alternate packet types.
+
+## Authority Model
+
+Runtime must:
+
+- Validate the packet
+- Execute the requested action
+- Enforce resource budgets (tokens, GPU-seconds, cost)
+- Return success or failure as a response packet
+- Preserve trace context
+- Respect concurrency limits
+- Append exactly one entry to `hop_trace`
+
+Runtime must not:
+
+- Decide the next workflow step
+- Trigger retries or compensation
+- Perform routing
+- Maintain workflow control state
+- Call other nodes directly
+- Call Gate without going through the SDK
+- Emit follow-up packets without orchestrator authority
+
+## State Model
+
+**Boundedly stateful.** Allowed local state:
+
+- Execution-local state (request-scoped)
+- Caches
+- Model or session state
+- Tool state
+
+Forbidden state:
+
+- Workflow DAG
+- Cross-step orchestration state
+- Replay or compensation authority
+- Authoritative cross-step history
+
+## Execution Properties
+
+- Isolated
+- Bounded
+- Deterministic where possible
+- Stateless where possible
+
+## Module Layout
+
+```
+execution/     agent_executor.py resource_budget.py state_manager.py
+memory/        semantic_retriever.py episodic_store.py
+scaling/       autoscaler.py pool_manager.py
+```
+
+## Guarantees
+
+- Resource limits respected
+- Explicit success or failure returned
+- Diagnostics included in failure packets
+- Trace context preserved
+- `hop_trace` appended with the runtime's `node_name` exactly once per packet

--- a/docs/boundaries/WHAT_LIVES_WHERE.md
+++ b/docs/boundaries/WHAT_LIVES_WHERE.md
@@ -1,0 +1,46 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, boundaries]
+tags: [L9_TEMPLATE, boundaries, placement]
+owner: platform
+status: active
+/L9_META -->
+
+# What Lives Where — Canonical Placement
+
+| Concern | Lives In | Forbidden In |
+|---|---|---|
+| HTTP routes (FastAPI) | `chassis/` | `engine/`, runtime modules |
+| Auth (API keys, signature) | `chassis/auth.py` | engines |
+| Tenant resolution | `chassis/tenant.py` | engines |
+| Rate limiting / circuit breaker / load shedding | Gate `resilience/` | runtime, orchestrator |
+| Node registry | Gate `routing/node_registry.py` | runtime, orchestrator |
+| Workflow DAG, step state, replay, compensation | Orchestrator `engine/`, `compensation/` | gate, runtime |
+| Mission kernel | Orchestrator only | everywhere else |
+| Capability execution | Runtime `execution/` | gate, orchestrator |
+| Resource budgets | Runtime `execution/resource_budget.py` | gate, orchestrator |
+| Vector / KG retrieval | Runtime `memory/` | gate |
+| Autoscaling | Runtime `scaling/` | gate |
+| Trace context propagation | SDK + transport (gate-client) | nodes redefining propagation |
+| Span creation at boundaries | SDK | nodes redefining boundaries |
+| Workflow attributes on spans | Orchestrator | gate, runtime |
+| Execution attributes on spans | Runtime | gate, orchestrator |
+| Idempotency dedup | Gate | nodes |
+| Replay protection | Gate (transport-level), Orchestrator (semantic) | runtime |
+| Domain spec | `domains/<id>/spec.yaml` | hardcoded values |
+| Dockerfile / CI / Terraform | `l9-template`, `infrastructure/`, `deploy/` | per-engine repos |
+
+## Quick Decision Table
+
+| If you are about to write… | Stop and put it in… |
+|---|---|
+| `from fastapi import APIRouter` in an engine | the chassis or remove it |
+| A workflow check inside Gate | the orchestrator |
+| A direct `httpx.post` to another node | the gate-client SDK |
+| A new transport envelope class | nowhere — use `TransportPacket` |
+| Mission state in a runtime handler | the orchestrator |
+| A custom `/v1/orchestrate` route | nowhere — orchestrator uses `/v1/execute` like every node |
+| Retry semantics in runtime | the orchestrator |
+| Workflow DAG persistence in Gate | the orchestrator |

--- a/docs/contracts/BREAKING_CHANGE_POLICY.md
+++ b/docs/contracts/BREAKING_CHANGE_POLICY.md
@@ -1,0 +1,62 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, contracts]
+tags: [L9_TEMPLATE, contracts, versioning]
+owner: platform
+status: active
+/L9_META -->
+
+# Breaking-Change Policy
+
+> Contracts are public APIs between authorities. Breaking them silently is the worst-case failure mode of an L9 system.
+
+## Versioning
+
+`{major}.{minor}.{patch}`
+
+| Change | Bump |
+|---|---|
+| Field rename, removal, semantic change | **Major** |
+| New field, new optional section, new enum value | Minor |
+| Clarification, typo, non-normative example | Patch |
+
+## Procedure for a Breaking Change
+
+1. **ADR.** Open `docs/adr/NNNN-{slug}.md` with motivation, alternatives, migration plan.
+2. **Bump contract major.** Mark prior version `status: superseded`.
+3. **Land dual-read adapter** behind a feature flag. The adapter accepts both old and new shapes and emits the new shape downstream.
+4. **Roll out producers** to the new shape.
+5. **Verify all consumers report new version.** Telemetry: `transport.packet.contract_version{value}`.
+6. **Remove the adapter.** Delete the superseded contract file in the same release.
+
+## What Counts As Breaking
+
+- Renaming a field
+- Removing a field
+- Changing a field's type
+- Tightening a constraint that previously-valid messages no longer satisfy
+- Removing an enum value
+- Changing the meaning of an existing enum value
+- Changing the canonical hash inputs
+
+## What Counts As Non-Breaking
+
+- Adding an optional field
+- Adding a new enum value (consumers must accept unknown values forward-compatibly)
+- Adding a new optional section
+- Tightening server-side validation in a way that *rejects previously invalid* messages
+
+## Forward Compatibility Rule
+
+Consumers must:
+
+- Accept unknown fields at the JSON level (drop or pass through).
+- Accept unknown enum values gracefully (treat as failure with `reason: UNSUPPORTED_VARIANT`, not crash).
+- Validate `header.schema_version` against their declared compatibility policy.
+
+## Enforcement
+
+- `tools/verify_contracts.py` checks every commit's contract diffs and rejects breaking changes without an ADR.
+- CI tags every release artifact with `contract.version` so consumers can audit which versions are in flight.

--- a/docs/contracts/DELEGATION_PROTOCOL.md
+++ b/docs/contracts/DELEGATION_PROTOCOL.md
@@ -1,0 +1,60 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, contracts]
+tags: [L9_TEMPLATE, contracts, delegation]
+owner: platform
+status: active
+/L9_META -->
+
+# Delegation Protocol
+
+Source contract: [`contracts/governance/delegation_chain.contract.yaml`](../../contracts/governance/delegation_chain.contract.yaml)
+
+## Purpose
+
+Carry scoped, time-bounded authorization across multi-hop flows. Every node that further delegates appends a grant. The chain is append-only and tamper-evident.
+
+## Grant Shape
+
+```yaml
+- delegator: <principal granting authority>
+  delegate:  <principal receiving authority>
+  scope:     [<capability tokens>]
+  issued_at: <ISO 8601 UTC>
+  expires_at: <ISO 8601 UTC>
+  signature: <optional detached signature>
+```
+
+## Invariants
+
+- Append-only.
+- Chain must root at the originator.
+- Each grant's `scope` must be ≤ the previous grant's scope (no widening).
+- Expired grants invalidate the entire packet.
+- Signature is optional but strongly recommended for cross-org delegation.
+
+## Scope Lattice
+
+Scopes form a partial order. Examples:
+
+- `execute:match` ≤ `execute:*`
+- `read:org:acme` ≤ `read:org:*`
+
+A child grant must request a subset of its parent's scope.
+
+## Enforcement Points
+
+- `gate_ingress_validator` — checks chain shape, expiry, root match.
+- `runtime_handler_pre_execute_check` — validates the action is in scope.
+- `orchestrator_step_authorization_check` — validates each step's required scope is granted.
+
+## Failure Modes
+
+| Condition | Reason |
+|---|---|
+| Empty chain when required | `DELEGATION_REQUIRED` |
+| Expired grant | `DELEGATION_EXPIRED` |
+| Scope widening violation | `SCOPE_WIDENING_FORBIDDEN` |
+| Originator mismatch | `DELEGATION_ROOT_MISMATCH` |

--- a/docs/contracts/NODE_REGISTRATION.md
+++ b/docs/contracts/NODE_REGISTRATION.md
@@ -1,0 +1,64 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, contracts]
+tags: [L9_TEMPLATE, contracts, registration]
+owner: platform
+status: active
+/L9_META -->
+
+# Node Registration
+
+Source contract: [`contracts/registration/node_registration.contract.yaml`](../../contracts/registration/node_registration.contract.yaml)
+
+## Endpoint
+
+```
+POST /v1/admin/register
+Authentication: gate_admin_credential
+```
+
+## Payload Shape
+
+A top-level JSON object keyed by node name:
+
+```yaml
+enrichment-engine:
+  internal_url: "http://enrichment-engine:8001"
+  supported_actions:
+    - enrich
+    - enrichment_request
+  priority_class: P1
+  max_concurrent: 16
+  health_endpoint: /v1/health
+  timeout_ms: 60000
+  metadata:
+    node_type: runtime
+    version: 1.4.2
+```
+
+## Required Fields
+
+- `internal_url` — absolute, primary route target.
+- `supported_actions` — non-empty list of lowercase snake_case action strings.
+
+## Optional Fields
+
+`priority_class` · `max_concurrent` · `health_endpoint` · `timeout_ms` · `metadata` · `public_url` · `capability_descriptor` · `protocol_compatibility` · `node_class` · `trust_tier` · `deployment_region` · `version`
+
+## Rules
+
+- Node names normalized to lowercase.
+- `supported_actions` must be non-empty (CI fails the build otherwise).
+- `internal_url` must be absolute.
+- Gate is authoritative for activation and health state — registration is a declaration, not a guarantee.
+- Registration may be rejected if `overwrite=false` and the node already exists.
+- Orchestrator registers as a normal node. No special treatment.
+
+## Health Lifecycle
+
+1. Node POSTs registration on boot.
+2. Gate marks node `active` only after a successful health probe.
+3. Health probe failures move the node to `unhealthy` — admission begins shedding.
+4. After N consecutive failures, the node is marked `inactive` and removed from routing.

--- a/docs/contracts/PACKET_TYPE_REGISTRY.md
+++ b/docs/contracts/PACKET_TYPE_REGISTRY.md
@@ -1,0 +1,50 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, contracts]
+tags: [L9_TEMPLATE, contracts, packet_types]
+owner: platform
+status: active
+/L9_META -->
+
+# Packet Type Registry
+
+`header.packet_type` is a closed enum. **Values may be added; values may never be renamed or removed.** All values are lowercase snake_case.
+
+## Canonical Transport Packet Types
+
+| Value | Meaning |
+|---|---|
+| `request` | Inbound request to a node |
+| `response` | Synchronous response packet |
+| `event` | Fire-and-forget signal |
+| `command` | Imperative directive (rare) |
+| `delegation` | Authority transfer (uses delegation_chain) |
+| `failure` | Structured failure result |
+| `replay_request` | Orchestrator-issued replay |
+| `replay_response` | Result of a replay |
+| `compensation` | Saga compensation step |
+
+## Domain Packet Types (legacy / payload-level)
+
+These appear in earlier specs as `payload.kind` discriminators. They are **not** valid `header.packet_type` values. Use `request`/`response` at the transport layer; carry the domain semantic in the payload:
+
+`memory_write` · `memory_read` · `reasoning_trace` · `tool_call` · `tool_result` · `tool_audit` · `insight` · `consolidation` · `world_model_update` · `identity_fact` · `graph_sync` · `graph_match` · `gds_job` · `enrichment_request` · `enrichment_result` · `score_record` · `routing_decision` · `signal_event` · `health_assessment` · `forecast_snapshot` · `handoff_document`
+
+## Common Mistakes
+
+| Wrong | Right |
+|---|---|
+| `"ENRICHMENT_RESULT"` | `"response"` with payload `kind: enrichment_result` |
+| `"enrichResult"` | lowercase snake_case in payload |
+| `"match_result"` | `"response"` with payload `kind: graph_match` |
+| `"GRAPH_MATCH"` | `"graph_match"` (in payload, not header) |
+
+## Adding a New Type
+
+1. Add to this file.
+2. Add to the enum in `transport/transport_packet.schema.json`.
+3. Add validation in the gate ingress validator.
+4. Bump the contract minor version.
+5. Land an ADR if the new type implies new authority semantics.

--- a/docs/contracts/ROUTING_POLICY.md
+++ b/docs/contracts/ROUTING_POLICY.md
@@ -1,0 +1,54 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, contracts]
+tags: [L9_TEMPLATE, contracts, routing]
+owner: platform
+status: active
+/L9_META -->
+
+# Routing Policy
+
+Source contract: [`contracts/routing/routing_policy.contract.yaml`](../../contracts/routing/routing_policy.contract.yaml)
+
+See also: [`docs/architecture/ROUTING.md`](../architecture/ROUTING.md) for the architectural rationale.
+
+## Hard Rule
+
+**All node-originated follow-up traffic returns to Gate.** Workers never know peer URLs.
+
+## Patterns
+
+| Allowed | Forbidden |
+|---|---|
+| `client → gate` | `node_a → node_b` |
+| `node → gate` | `orchestrator → worker (direct)` |
+| `gate → worker` | `worker → worker` |
+
+## Selection Algorithm (Gate)
+
+```
+input:    packet.header.action
+step 1:   lookup action in NodeRegistry
+step 2:   filter health == active
+step 3:   filter priority class eligibility
+step 4:   admission_controller.check(node)
+step 5:   dispatcher.dispatch(node, packet)
+```
+
+## Required Provenance
+
+| Origin | `provenance.origin_kind` | `address.source_node` | `address.destination_node` |
+|---|---|---|---|
+| External client | `client` | client id | `gate` |
+| Node follow-up | `node` | local node | `gate` |
+| Gate dispatch | `gate` | `gate` | resolved worker |
+
+## Failure Modes
+
+| Reason | Returned |
+|---|---|
+| Action not registered | `failure_packet(reason="UNROUTABLE")` |
+| No healthy node | `failure_packet(reason="NODE_UNAVAILABLE")` |
+| Admission denied | `failure_packet(reason="ADMISSION_DENIED")` |

--- a/docs/contracts/TRANSPORT_PACKET.md
+++ b/docs/contracts/TRANSPORT_PACKET.md
@@ -1,0 +1,83 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, contracts]
+tags: [L9_TEMPLATE, contracts, transport_packet]
+owner: platform
+status: active
+/L9_META -->
+
+# TransportPacket — Authoring Guide
+
+Source contract: [`contracts/transport/transport_packet.contract.yaml`](../../contracts/transport/transport_packet.contract.yaml)
+Source schema: [`contracts/transport/transport_packet.schema.json`](../../contracts/transport/transport_packet.schema.json)
+
+## What It Is
+
+The single canonical execution contract for every L9 system. Every packet on every wire — client→gate, gate→worker, worker→gate — is a `TransportPacket`. There are no other envelopes.
+
+## Required Sections
+
+| Section | Why |
+|---|---|
+| `header` | Identity, type, action, timing, schema version |
+| `address` | Source, destination, reply path |
+| `tenant` | Multi-tenant isolation and audit |
+| `payload` | Action-specific data (the only field that varies per domain) |
+| `security` | Hashes, classification, encryption status, PII declarations |
+| `governance` | Intent, compliance tags, retention, audit flag |
+| `provenance` | Origin kind, requested vs resolved action |
+| `delegation_chain` | Append-only scoped authorizations |
+| `hop_trace` | Append-only tamper-evident routing journal |
+| `lineage` | Root, parent, generation |
+| `attachments` | Out-of-band references (URI + sha256 + media type) |
+
+## Construction Rules
+
+- **Immutable execution record.** Once constructed, never mutated.
+- **Semantic change requires `derive()`.** A new packet referencing the parent.
+- **Observational hop requires `with_hop()`.** Appends to `hop_trace` without semantic change.
+- Two hashes:
+  - `payload_hash = sha256(canonical_json(payload))`
+  - `transport_hash = sha256(canonical_json(stable core, excluding hop_trace))`
+
+## Lineage Rules
+
+| Packet kind | `parent_id` | `root_id` | `generation` |
+|---|---|---|---|
+| Root | `null` | `self.packet_id` | 0 |
+| Child | `parent.packet_id` | `parent.root_id` | `parent.generation + 1` |
+
+## Response Rules
+
+- A response is itself a `TransportPacket` with `packet_type: response`.
+- Preserve the original `packet_id`.
+- Reverse `address.source_node` ↔ `address.destination_node`.
+- Carry the execution result in `payload`.
+
+## Idempotency
+
+`header.idempotency_key` is the dedup key. Gate enforces it. Same key → same response packet, byte-for-byte.
+
+## Replay Protection
+
+`header.packet_id` is the replay identity. Gate's `replay_guard` rejects duplicate packet receipts at transport level.
+
+## Anti-Patterns (rejected at CI)
+
+- Direct node-to-node calls
+- In-place packet mutation
+- Multiple transport schemas
+- Raw HTTP `POST /v1/execute` with untyped dicts
+- `PacketEnvelope` as active canonical contract
+
+## Common Mistakes
+
+| Wrong | Right |
+|---|---|
+| `packet.payload["new_field"] = value` | `new = packet.derive(mutation={"payload": {**packet.payload, "new_field": value}})` |
+| `await httpx.post(other_node_url, ...)` | `await gate_client.execute(new_packet)` |
+| `packet_type: "ENRICHMENT_RESULT"` | `packet_type: "response"` (with payload semantics) |
+| Setting `lineage.parent_id` to an arbitrary id | Always derive — `derive()` sets it correctly |
+| Skipping `hop_trace` | Every node receiving a packet appends one entry |

--- a/docs/observability/LOGGING.md
+++ b/docs/observability/LOGGING.md
@@ -1,0 +1,80 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, observability]
+tags: [L9_TEMPLATE, observability, logging]
+owner: platform
+status: active
+/L9_META -->
+
+# Logging
+
+## Standard
+
+structlog JSON, single line per event, UTC ISO 8601 timestamps.
+
+## Required Fields (every log line)
+
+- `ts` — ISO 8601 UTC
+- `level` — `debug | info | warning | error | critical`
+- `logger` — module name (`__name__`)
+- `event` — short, lowercase, snake_case event identifier
+- `trace_id` — propagated from packet header
+- `tenant_id` — `tenant.org_id` (never user_id)
+- `action` — action being processed
+- `node_name` — current node identity
+
+## Engine Usage
+
+```python
+import structlog
+
+log = structlog.get_logger(__name__)
+
+log.info(
+    "match_started",
+    domain_id=domain.id,
+    candidate_count=len(candidates),
+)
+```
+
+Engines call `structlog.get_logger(__name__)` and nothing else. Configuration is the chassis's job.
+
+## Forbidden
+
+- `structlog.configure()` in `engine/`
+- `logging.basicConfig()` in `engine/`
+- Logging PII values (the chassis filters declared PII paths; never bypass)
+- Logging secrets (rotate immediately if a secret is logged)
+- Logging full packet payloads at `info` or higher (use `debug` and only in dev)
+
+## Levels
+
+| Level | Use For |
+|---|---|
+| `debug` | Verbose state, payload bodies (dev only) |
+| `info` | Normal lifecycle events, expected outcomes |
+| `warning` | Degraded behavior, retries, fallbacks |
+| `error` | Handler failures, validation rejections |
+| `critical` | Process-level failures, integrity violations |
+
+## Redaction
+
+Configured by `chassis/middleware.py` based on declared PII fields in the domain spec (`compliance.pii.fields`). Modes: `hash`, `encrypt`, `redact`, `tokenize`. The redactor runs before structlog serialization.
+
+## Backends
+
+- **Local dev** — stdout
+- **Production** — Loki via Alloy collector (`observability/QW1_alloy_config.alloy`)
+- **Long-term archive** — S3 (lifecycle policy: 30 days hot, 1 year cold)
+
+## Forbidden Anti-Patterns
+
+| Pattern | Why |
+|---|---|
+| `print(...)` in `engine/` | Bypasses structlog and trace context |
+| `logging.getLogger()` in `engine/` | Bypasses structlog config |
+| Multi-line log messages | Breaks JSON parsing in Loki/ELK |
+| F-strings inside log calls | Use kwargs so structlog can structure them |
+| Logging in tight loops | Use sampling or aggregate first |

--- a/docs/observability/METRICS.md
+++ b/docs/observability/METRICS.md
@@ -1,0 +1,72 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, observability]
+tags: [L9_TEMPLATE, observability, metrics]
+owner: platform
+status: active
+/L9_META -->
+
+# Metrics
+
+Source contract: [`contracts/observability/metrics.contract.yaml`](../../contracts/observability/metrics.contract.yaml)
+
+## Surface
+
+`GET /metrics` — Prometheus / OpenMetrics format. Configured by the chassis. Engines emit via `chassis.metrics`.
+
+## SDK Metrics (every node)
+
+- `transport_packets_received_total`
+- `transport_packets_sent_total`
+- `transport_packet_failures_total`
+- `transport_propagation_failures_total`
+- `transport_span_creation_failures_total`
+- `transport_hop_duration_ms` (histogram)
+
+## Gate Metrics
+
+- `gate_dispatch_latency_ms` (histogram)
+- `gate_routing_failures_total`
+- `gate_trace_context_missing_total`
+- `gate_admission_denials_total{reason}`
+- `gate_circuit_breaker_state{node}`
+- `gate_idempotency_cache_hits_total`
+
+## Orchestrator Metrics
+
+- `orchestrator_workflow_decision_latency_ms`
+- `orchestrator_trace_link_failures_total`
+- `workflows_started_total`
+- `workflows_completed_total{terminal_status}`
+- `orchestrator_replay_total{outcome}`
+- `orchestrator_compensation_total{outcome}`
+
+## Runtime Metrics
+
+- `runtime_handler_latency_ms{action}` (histogram)
+- `runtime_handler_failures_total{action,reason}`
+- `runtime_resource_budget_exceeded_total{budget_kind}`
+- `runtime_concurrent_executions{action}` (gauge)
+
+## Cardinality Rules
+
+| Rule | Reason |
+|---|---|
+| Never label with `packet_id` | Unbounded cardinality |
+| Never label with `user_id` | Unbounded cardinality |
+| Never label with free-form strings | Unbounded cardinality |
+| `tenant_id` is `org_id` only | Bounded by tenant count |
+| `action` is from registered set only | Bounded by registered actions |
+
+## Default SLO Targets
+
+| Metric | Target |
+|---|---|
+| `gate_dispatch_p99_ms` | ≤ 25ms |
+| `runtime_handler_p99_ms` | ≤ 200ms |
+| Workflow end-to-end success rate | ≥ 99.9% |
+| Trace completeness | ≥ 99.5% |
+
+SLOs are enforced by Grafana alerts in `observability/P2_5_grafana_slo_dashboard.json`.

--- a/docs/observability/TRACING.md
+++ b/docs/observability/TRACING.md
@@ -1,0 +1,70 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, observability]
+tags: [L9_TEMPLATE, observability, tracing]
+owner: platform
+status: active
+/L9_META -->
+
+# Tracing
+
+Source contract: [`contracts/observability/trace_propagation.contract.yaml`](../../contracts/observability/trace_propagation.contract.yaml)
+
+## Standard
+
+W3C Trace Context, propagated through `header.trace_id`, `header.span_id`, `header.trace_flags`, `header.tracestate` on every `TransportPacket`.
+
+## Ownership
+
+| Owner | Responsibility |
+|---|---|
+| SDK | Extract / inject trace context · create boundary spans · transport metrics · hop timing |
+| Gate | Preserve inbound trace context · create dispatch spans · annotate routing |
+| Orchestrator | Workflow decision spans · workflow attributes · trace ↔ workflow correlation |
+| Runtime | Execution spans · validation spans · execution attributes |
+| Governance | Enforcement of the contract · forbidden-behavior detection |
+
+## Required Spans
+
+- `gate_ingress`
+- `gate_dispatch`
+- `node_receive`
+- `node_handler`
+- `node_emit`
+
+Optional spans: `workflow_decision`, `fan_out_coordination`, `replay_evaluation`, `compensation_evaluation`, `runtime_execution`, `runtime_validation`, `persistence_write`.
+
+## Required Attributes (every span)
+
+- `trace_id`
+- `node_name`
+- `action`
+- `tenant_id` (always `tenant.org_id`, never user_id)
+- `packet_type`
+- `root_id`
+
+Gate-specific: `destination_node`, `requested_action`, `resolved_action`, `routing_policy_version`.
+Orchestrator-specific: `workflow_id`, `step_id`, `replay_epoch`, `compensation_status`.
+Runtime-specific: `execution_id`, `capability_name`, `result_status`, `execution_ms`.
+
+## Propagation Rules
+
+- `trace_id` is preserved across derivation. Never replaced if valid.
+- Missing `trace_id` → SDK generates a new valid one.
+- Malformed → replaced with new valid trace + diagnostic emission.
+- `span_id` may change only at a new boundary span.
+- `trace_flags` and `tracestate` preserved when present.
+
+## Forbidden
+
+- Detached async work creating new traces without governed policy.
+- Replacing a valid inbound `trace_id`.
+- Using trace data as a hidden control plane (no decisions read from spans).
+
+## Backends
+
+- **Local dev** — Tempo via Docker Compose
+- **Production** — Grafana Tempo (or equivalent) behind OpenTelemetry Collector
+- **Sampling** — head-based, configurable per environment in `observability/QW4_otel_collector_sampling.yaml`

--- a/docs/runbooks/DEPLOY.md
+++ b/docs/runbooks/DEPLOY.md
@@ -1,0 +1,91 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, runbooks]
+tags: [L9_TEMPLATE, runbooks, deploy]
+owner: platform
+status: active
+/L9_META -->
+
+# Deploy Runbook
+
+> The standard deploy path is **GitHub Actions → 3-LLM stacked review → merge → ArgoCD auto-deploy → Telegram notification**. This runbook covers the manual fallback and the production checklist.
+
+## Pre-Deploy Checklist
+
+- [ ] All required CI checks green (lint · type-check · contracts · unit · integration · compliance · LLM review)
+- [ ] Contract version pinned in `contracts/_schemas/` and matches handler signatures
+- [ ] No new top-level directories without ADR
+- [ ] `CHANGELOG.md` updated
+- [ ] If breaking contract change: ADR merged and dual-read window planned
+- [ ] `scripts/predeploy_check.py` passes against target env
+
+## Standard Deploy (ArgoCD)
+
+1. PR merges to `main`.
+2. GitHub Actions builds and pushes container to registry, signed with cosign.
+3. ArgoCD detects new image tag, syncs to staging.
+4. Smoke tests run (`tools/infra/precommit_smoke.sh`).
+5. Manual approval (or auto for non-prod).
+6. ArgoCD syncs to production canary (10%).
+7. SLO monitor watches for 15 minutes.
+8. Auto-promote to 100% if SLOs hold; auto-rollback if they do not.
+9. Telegram notification on success or failure.
+
+## Manual Deploy (fallback)
+
+```bash
+# 1. Build
+tools/infra/docker_validate.sh
+docker build -f infrastructure/docker/Dockerfile -t <registry>/<service>:<sha> .
+docker push <registry>/<service>:<sha>
+
+# 2. Predeploy check
+scripts/predeploy_check.py --env=production
+
+# 3. Deploy
+deploy/scripts/deploy_remote.sh --env=production --tag=<sha>
+
+# 4. Verify
+curl -f https://<host>/v1/health
+curl -f https://<host>/v1/readiness
+```
+
+## Rollback
+
+```bash
+deploy/scripts/rollback_remote.sh --env=production --to=<previous_sha>
+```
+
+Rollback restores the previous container image. Persistent state migrations should always be **forward-compatible** — schema changes use `expand → migrate → contract` so a rollback never corrupts data.
+
+## Database Migrations
+
+- Forward-compatible: add column nullable, backfill, drop default in next release.
+- Never: rename a column in one release; never drop a column the previous release reads.
+- Migration tool: `database/init_db.py` + Alembic-style versioned scripts.
+
+## Secrets
+
+- Source: AWS Secrets Manager, RAM-only via `secure-env.sh`.
+- **Never** commit secrets. **Never** log secrets. GitGuardian enforces both.
+- Rotate quarterly or on incident.
+
+## Post-Deploy Verification
+
+| Check | How |
+|---|---|
+| Health | `GET /v1/health` returns 200 |
+| Readiness | `GET /v1/readiness` returns 200 with `ready=true` |
+| Registration | Node visible in Gate `node_registry` and `active` |
+| Trace propagation | Sample request shows full span chain in Grafana Tempo / Jaeger |
+| Metrics | `/metrics` scraped; SLO dashboards updated |
+| Smoke action | Send canonical `TransportPacket` for a known action; assert response shape |
+
+## Telegram Notification Format
+
+- Success: `✓ <service>@<sha> → <env> · ${duration}s`
+- Failure: `✗ <service>@<sha> → <env> · failed: <stage> · <link to logs>`
+
+(Emojis only because the Telegram channel uses them — never in source artifacts.)

--- a/docs/runbooks/INCIDENT.md
+++ b/docs/runbooks/INCIDENT.md
@@ -1,0 +1,92 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, runbooks]
+tags: [L9_TEMPLATE, runbooks, incident]
+owner: platform
+status: active
+/L9_META -->
+
+# Incident Response
+
+## Severity
+
+| Level | Definition | Response |
+|---|---|---|
+| **SEV-1** | Customer-facing outage; data loss; security breach | Page on-call · war room · status page within 15 min |
+| **SEV-2** | Significant degradation; SLO at risk; major feature broken | Page on-call · incident channel · status page within 60 min |
+| **SEV-3** | Minor degradation; no SLO breach; partial feature broken | Ticket · address in business hours |
+| **SEV-4** | Cosmetic; no user impact | Backlog |
+
+## First 10 Minutes
+
+1. **Acknowledge** the page within 5 minutes.
+2. **Assess severity** — SEV-1/2 require immediate war-room.
+3. **Open incident channel** `#inc-<short-name>`.
+4. **Post initial status** — what you know, what you don't, ETA for next update.
+5. **Assign roles**: Incident Commander · Comms Lead · Tech Lead.
+
+## Triage
+
+### Is Gate routing?
+
+```bash
+# Recent 5xx by node
+curl -s gate:9090/api/v1/query?query='sum by(node)(rate(gate_routing_failures_total[5m]))'
+# Trace context missing
+curl -s gate:9090/api/v1/query?query='rate(gate_trace_context_missing_total[5m])'
+```
+
+### Is a node draining or unhealthy?
+
+```bash
+gh api repos/cryptoxdog/golden-repo/contents/contracts/registration  # check expected nodes
+# Then for each node:
+curl -f https://<node>/v1/health
+curl -f https://<node>/v1/readiness
+```
+
+### Is the workflow authority advancing?
+
+```bash
+# Workflows started but not completed
+curl -s orch:9090/api/v1/query?query='workflows_started_total - workflows_completed_total'
+```
+
+### Is admission blocking traffic?
+
+```bash
+curl -s gate:9090/api/v1/query?query='sum by(reason)(rate(gate_admission_denials_total[5m]))'
+```
+
+## Common Root Causes
+
+| Symptom | Likely Cause | Mitigation |
+|---|---|---|
+| `UNROUTABLE` errors spike | Node deregistered or supported_actions empty | Re-register node; check `predeploy_check` output |
+| `NODE_UNAVAILABLE` errors spike | Health probes failing | Inspect node logs; check resource exhaustion |
+| `ADMISSION_DENIED` errors spike | Circuit breaker tripped or load shedding | Check upstream stability; tune thresholds |
+| Trace gaps | Detached async work; SDK not propagating | Audit code for LAW-08 violations |
+| Memory growth on Runtime | Bounded state guarantees broken | Audit `state_manager.py`; check cache eviction |
+| Workflows stuck | Orchestrator checkpoint store unreachable | Check Postgres/Redis; trigger replay from last good checkpoint |
+| Tenant isolation violation | Cross-tenant query | SEV-1 — pull node, audit, root-cause, postmortem |
+
+## Communication Cadence
+
+- **SEV-1**: status update every 30 min until resolved.
+- **SEV-2**: status update every 60 min until resolved.
+- **All sev**: final "resolved" message with timeline + root cause summary.
+
+## Postmortem
+
+Within 5 business days of any SEV-1 or SEV-2:
+
+- Timeline (UTC, minute-resolution)
+- Impact (customers, duration, data)
+- Root cause (technical + organizational)
+- What went well
+- What went poorly
+- Action items (each owned, dated, tracked in Linear)
+
+Postmortems are blameless and published to the team. ADRs are opened for any structural change identified.

--- a/docs/runbooks/ON_CALL.md
+++ b/docs/runbooks/ON_CALL.md
@@ -1,0 +1,66 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, runbooks]
+tags: [L9_TEMPLATE, runbooks, on_call]
+owner: platform
+status: active
+/L9_META -->
+
+# On-Call
+
+## Schedule
+
+- **Primary** rotates weekly. Schedule managed in the team paging tool.
+- **Secondary** is the previous week's primary, on call only if primary cannot acknowledge.
+- **Manager escalation** for SEV-1 not acknowledged within 15 minutes.
+
+## What You Are Responsible For
+
+- Acknowledging pages within 5 minutes.
+- Triaging incidents per [`INCIDENT.md`](INCIDENT.md).
+- Keeping the incident channel updated.
+- Filing a postmortem within 5 business days for any SEV-1 / SEV-2.
+- **Not** fixing every problem yourself — pull in domain experts when needed.
+
+## Pre-Shift Checklist
+
+- [ ] Paging tool installed and tested
+- [ ] VPN access verified
+- [ ] kubectl / docker / gh / terraform CLIs working
+- [ ] Read the previous week's incident summaries
+- [ ] Check for any deferred work that may surface during the shift
+- [ ] Confirm contact for Hetzner support (current hosting provider)
+
+## Tools You Need
+
+| Tool | Use |
+|---|---|
+| Grafana | SLO dashboards, recent error rates |
+| Tempo / Jaeger | Trace inspection |
+| Loki / ELK | Log search |
+| Prometheus | Ad-hoc queries |
+| `gh` CLI | Read recent deploys, file issues |
+| `kubectl` / `docker compose` | Inspect pods/containers |
+| Telegram | Deploy notifications |
+
+## Pages You Will Receive
+
+| Alert | Likely Action |
+|---|---|
+| Gate `dispatch_p99 > 100ms` | Check downstream node health |
+| Gate `routing_failures_total` rate spike | Triage by `reason` label |
+| Workflow stalled (`workflows_started - workflows_completed > N`) | Inspect Orchestrator logs; trigger replay |
+| Runtime `handler_failures_total` spike | Check resource budget; check upstream dep |
+| `transport_packet_schema_validation_failures` spike | Recent deploy of mismatched contract version — rollback |
+| Tenant isolation alert | SEV-1, immediate response |
+
+## Handoff
+
+End-of-shift handoff to the next primary includes:
+
+- Open incidents (status, owner, next action)
+- Recent deploys still in canary
+- Known noisy alerts and their workarounds
+- Pending postmortem action items

--- a/docs/security/BOUNDARIES.md
+++ b/docs/security/BOUNDARIES.md
@@ -1,0 +1,72 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, security]
+tags: [L9_TEMPLATE, security, boundaries]
+owner: platform
+status: active
+/L9_META -->
+
+# Boundary Enforcement
+
+> Documentation describes boundaries. Code enforces them. CI fails the build when code drifts.
+
+## Static Enforcement
+
+| Check | Tool | Source |
+|---|---|---|
+| Banned-pattern scan | `tools/contract_scanner.py` | `docs/agents/CODING_GUIDE.md` §4 |
+| Architecture import boundary | `tools/review/analyzers/architecture_boundary.py` | `tools/review/policy/architecture.yaml` |
+| Contract presence + wiring | `tools/verify_contracts.py` | `contracts/` |
+| Type strictness | `mypy --strict engine/` | `mypy.ini` |
+| L9_META present | `tools/l9_meta_injector.py --check` | per-file header |
+| Cypher safety | `tests/contracts/test_cypher_safety.py` (planned) | `LAW-09` |
+
+## Runtime Enforcement
+
+| Check | Owner | Failure Mode |
+|---|---|---|
+| `TransportPacket` schema | Gate ingress validator + Runtime handler | reject with `schema_violation` |
+| Routing policy provenance | Gate routing validator | reject with `INVALID_PROVENANCE` |
+| Idempotency dedup | Gate | return cached response packet |
+| Replay protection | Gate | reject with `REPLAY_DETECTED` |
+| Delegation scope | Gate + Runtime + Orchestrator | reject with `SCOPE_WIDENING_FORBIDDEN` |
+| Tenant isolation | Query layer | reject with `CROSS_TENANT_FORBIDDEN` |
+| Prohibited factors | Gate compiler at domain spec validation | fail compilation |
+
+## CI Build Fails If
+
+(From `gate.contract.yaml.ci_enforcement_rules`)
+
+- `PacketEnvelope` imports exist in TransportPacket-native repos
+- Direct node-to-node calls exist
+- Raw HTTP posts to `/v1/execute` bypass the gate-client SDK
+- Runtime contains workflow logic
+- Gate contains workflow state
+- Orchestrator bypasses Gate
+- Non-`TransportPacket` execute path exists
+- Packet mutation occurs without `derive()` or `with_hop()`
+- Routing policy is bypassed
+- Handler signature is not `TransportPacket → TransportPacket`
+- `TransportPacket` schema validation is missing at gate ingress
+- Node registration `supported_actions` is empty
+
+## Runtime Audit
+
+- Every blocked attempt at a prohibited factor is logged with `tenant.org_id`, actor, source file, source line, rejection reason.
+- Every cross-boundary reject (provenance, scope, schema) emits a metric labeled by reason.
+
+## Boundary Diagram
+
+```
+External                             Internal trusted              Persistent
+┌─────────┐    HTTPS+API key   ┌─────┐  mTLS+TransportPacket  ┌─────────┐    tenant-scoped
+│ Client  │ ─────────────────▶ │Gate │ ──────────────────────▶│ Workers │ ─────────────────▶ Stores
+└─────────┘                    └─────┘                        └─────────┘
+            schema validate ▲           routing policy  ▲       sanitize_label ▲
+            authn/authz     │           admission       │       parameterized  │
+            replay guard    │           idempotency     │       tenant scope   │
+```
+
+Each `▲` is a contract-enforced check. Removing any one of them fails CI.

--- a/docs/security/SECRETS.md
+++ b/docs/security/SECRETS.md
@@ -1,0 +1,61 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, security]
+tags: [L9_TEMPLATE, security, secrets]
+owner: platform
+status: active
+/L9_META -->
+
+# Secrets Management
+
+## Sources
+
+| Source | Use |
+|---|---|
+| AWS Secrets Manager | Production secrets; canonical source of truth |
+| Doppler / Vault (alternative) | Dev/staging environments |
+| `.env.local` (developer machine only) | Local dev — never committed |
+
+## Loading
+
+- Production: `secure-env.sh` fetches secrets from AWS Secrets Manager into RAM-only env vars at process start. Never written to disk.
+- Local: `.env.local` (gitignored) loaded by `chassis/settings.py`.
+- All env vars consumed via `pydantic-settings`. Engines never read os.environ directly.
+
+## Naming Convention
+
+- All L9 platform env vars are prefixed `L9_`.
+- Engine-specific vars use `L9_<ENGINE>_` (e.g., `L9_GATE_NEO4J_URI`, `L9_RUNTIME_OPENAI_API_KEY`).
+- Secret references in IaC use the AWS Secrets Manager key name only — never the value.
+
+## Rules
+
+- **Never** commit secrets. GitGuardian enforces this on every push.
+- **Never** log secrets. structlog redaction filters are configured by the chassis.
+- **Never** include secrets in error messages, traces, or telemetry.
+- **Always** use SHA-256 with constant-time comparison for API key verification (`hmac.compare_digest`).
+- **Always** rotate secrets quarterly and on incident.
+
+## Rotation Procedure
+
+1. Generate new secret in AWS Secrets Manager (versioned).
+2. Roll out to all consumers via deploy.
+3. Verify production traffic uses new secret (telemetry).
+4. Mark old secret as `AWSPENDING → AWSPREVIOUS`.
+5. After 24h grace, delete `AWSPREVIOUS`.
+
+## Compromise Procedure
+
+1. Rotate the compromised secret immediately.
+2. Audit logs for the lifetime of the secret to identify potential abuse.
+3. Open SEV-1 incident if customer data may have been accessed.
+4. Postmortem with root cause and structural fix (often: improved scope, shorter TTL, separate keys per consumer).
+
+## Forbidden
+
+- Hardcoded secrets in source.
+- Secrets in `git` history (rotate immediately if found; the secret IS compromised).
+- Sharing secrets via chat, email, or screenshots.
+- Single shared secret across multiple environments.

--- a/docs/security/THREAT_MODEL.md
+++ b/docs/security/THREAT_MODEL.md
@@ -1,0 +1,89 @@
+<!-- L9_META
+l9_schema: 1
+origin: l9-template
+engine: golden-repo
+layer: [docs, security]
+tags: [L9_TEMPLATE, security, threat_model]
+owner: platform
+status: active
+/L9_META -->
+
+# Threat Model
+
+> Methodology: STRIDE per data flow, applied at each authority boundary.
+
+## Trust Boundaries
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  TRUST 0  │ External clients (untrusted)                  │
+└──────────────────────────────────────────────────────────┘
+         │ HTTPS · API key · TransportPacket schema validation
+         ▼
+┌──────────────────────────────────────────────────────────┐
+│  TRUST 1  │ Gate (transport authority)                    │
+└──────────────────────────────────────────────────────────┘
+         │ Internal network · mTLS · TransportPacket
+         ▼
+┌──────────────────────────────────────────────────────────┐
+│  TRUST 2  │ Orchestrator / Runtime (workload nodes)       │
+└──────────────────────────────────────────────────────────┘
+         │ Tenant-scoped · sanitize_label · parameterized queries
+         ▼
+┌──────────────────────────────────────────────────────────┐
+│  TRUST 3  │ Persistent stores (Neo4j · Postgres · Redis)  │
+└──────────────────────────────────────────────────────────┘
+```
+
+## STRIDE per Authority
+
+### Gate
+
+| Threat | Mitigation |
+|---|---|
+| **S**poofing | API key SHA-256 verify, constant-time compare, optional mTLS for node-to-gate |
+| **T**ampering | `transport_hash` + transport_signature on every packet; replay guard rejects re-injection |
+| **R**epudiation | `delegation_chain` + `hop_trace` are append-only and signed |
+| **I**nformation disclosure | TLS in transit; PII fields declared and redacted in logs; classification flag enforced |
+| **D**enial of service | Rate limiter, circuit breaker, load shedding, backpressure — all at Gate |
+| **E**levation of privilege | Tenant resolved by chassis; delegation scope can only narrow, never widen |
+
+### Orchestrator
+
+| Threat | Mitigation |
+|---|---|
+| Spoofing | Reachable only via Gate; orchestrator-bound packets carry `provenance.resolved_by_gate=true` |
+| Tampering | Workflow state checkpointed with content hash; replay reconstructs deterministically |
+| Repudiation | All step transitions emit signed `TransportPacket` events |
+| Information disclosure | Workflow state scoped by `tenant.org_id`; cross-tenant access forbidden by query layer |
+| DoS | Per-workflow concurrency limits; mission kernel back-pressure |
+| EoP | Step authorization checks `delegation_chain` before dispatch |
+
+### Runtime
+
+| Threat | Mitigation |
+|---|---|
+| Spoofing | Reachable only via Gate; packets validated against schema before handler |
+| Tampering | Packet immutable; `derive()` is the only mutation path |
+| Repudiation | Every execution appends one `hop_trace` entry with timing |
+| Information disclosure | PII fields hashed/encrypted/redacted/tokenized per domain spec |
+| DoS | Resource budgets (tokens, GPU-sec, cost); concurrency caps; autoscaler |
+| EoP | Sanitize all dynamic identifiers (Cypher labels) before interpolation; parameterized values |
+
+## High-Risk Surfaces
+
+1. **Domain spec upload** (`/v1/admin`) — untrusted YAML. Mitigations: schema validation, prohibited factors compile-time block, signed admin credential.
+2. **Cypher injection** — sanitize_label regex `^[A-Za-z_][A-Za-z0-9_]*$`; values always parameterized.
+3. **Cross-tenant data exposure** — every query scopes by `tenant.org_id`; integration tests enforce isolation.
+4. **Replay attacks** — Gate's `replay_guard` keyed on `header.packet_id`; idempotency keyed on `header.idempotency_key`.
+5. **Trace as control plane** — observability data must never carry decisions; this is contract-enforced in `trace_propagation.contract.yaml`.
+
+## Out of Scope
+
+- Physical hardware tampering (covered by hosting provider attestation)
+- Insider with full production credentials (covered by access governance)
+- Quantum-resistant crypto (tracked separately under Crypto Roadmap)
+
+## Reviews
+
+Threat model is reviewed per release boundary or on any architectural change crossing a trust boundary.

--- a/domains/README.md
+++ b/domains/README.md
@@ -1,0 +1,62 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: domains
+  tags: [domains, bounded-context, capabilities]
+  owner: platform
+  status: active
+-->
+
+# domains/
+
+One bounded context per subdirectory. Each domain declares its **packet types**, **actions**, **handlers**, and **schemas** — and nothing else.
+
+## Purpose
+
+Domains are how a node grows without becoming a monolith. A domain is a **slice of the engine** focused on one capability, with its own packet types, fixtures, and tests. Multiple domains compose into a node; multiple nodes compose into a constellation.
+
+## What lives in each domain
+
+A domain directory must contain:
+
+```
+domains/<domain_name>/
+├── README.md                  # Purpose, owners, packet types exposed
+├── actions.py                 # Action ids registered with the chassis
+├── handlers.py                # Handler functions; one per action
+├── models.py                  # Pydantic v2 domain models
+├── schemas/                   # JSON schemas for inbound/outbound payloads
+└── tests/                     # Domain-scoped unit and contract tests
+```
+
+`domains/example_domain/` is the canonical scaffold — copy it, do not branch from it.
+
+## What does NOT live here
+
+- **No transport.** Domains never import FastAPI, never bind sockets.
+- **No cross-domain reach.** A domain talks to another domain only by emitting a `TransportPacket` through the chassis client. No direct python imports across domain boundaries.
+- **No global state.** Domains are pure functions over packets and injected services.
+- **No infra config.** Database URLs, queue names, secrets — all come from the chassis settings layer.
+
+## Contracts that govern this directory
+
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — every action's I/O is a TransportPacket.
+- [`/contracts/runtime/runtime.contract.yaml`](../contracts/runtime/runtime.contract.yaml) — handler invariants apply per domain.
+- [`/contracts/governance/tenant_context.contract.yaml`](../contracts/governance/tenant_context.contract.yaml) — domains must not strip tenant context from responses.
+- Each domain SHOULD ship its own contract YAML under `contracts/domains/<domain_name>/<action>.contract.yaml` once the action stabilises.
+
+## Quality gates
+
+- Every domain action is covered by a contract test in `tests/contracts/`.
+- Every domain has ≥ 1 unit test per handler in `tests/unit/domains/<domain_name>/`.
+- `tools/auditors/` checks for cross-domain imports and fails CI on violations.
+- Domain README must enumerate the actions it exposes.
+
+## Conventions
+
+- Domain names: lowercase `snake_case`, no plurals.
+- Action ids: `<domain>.<verb>` — e.g. `billing.invoice_create`. Lowercase, snake_case throughout.
+- Packet types are versioned: `billing.invoice.v1`. Breaking changes ship a new version per the breaking-change policy.
+- A domain's public surface is its action ids — not its module layout. Refactor freely behind the action boundary.

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,0 +1,82 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: engine
+  tags: [engine, runtime, handlers, domain-logic]
+  owner: platform
+  status: active
+-->
+
+# engine/
+
+The **execution surface** of a node. Pure domain logic and packet handlers — no transport, no routing, no peer discovery.
+
+## Purpose
+
+`engine/` is where a node *does its job*. Every public function here takes a `TransportPacket`, returns a `TransportPacket`, and trusts that the chassis already validated, authenticated, and routed the request.
+
+If the chassis is the **how**, the engine is the **what**.
+
+## What lives here
+
+| Path | Responsibility |
+|---|---|
+| `engine/main.py` | Node entrypoint — registers handlers, exposes `app` for the chassis to mount. |
+| `engine/handlers.py` | `async def handler(packet: TransportPacket) -> TransportPacket` implementations. |
+| `engine/core/` | Pure business logic. No I/O frameworks, no FastAPI, no HTTP. |
+| `engine/services/` | Outbound calls to durable systems (DB, cache, object store) via injected clients. |
+| `engine/models/` | Domain models — pydantic v2, immutable where possible. |
+| `engine/security/` | Permission predicates, tenant guards, prohibited-factor checks. |
+| `engine/compliance/` | Hooks that emit audit events through the chassis audit sink. |
+| `engine/config/`, `settings.py` | Typed settings (pydantic-settings). Read once at boot. |
+| `engine/features.py`, `features.json` | Feature-flag surface, read-only at request time. |
+| `engine/hashing.py`, `metrics.py`, `logging.py`, `transaction.py` | Local utilities scoped to engine concerns. |
+
+## What does NOT live here
+
+- **No FastAPI imports.** `from fastapi import ...` in `engine/` is a CI failure. Routing belongs to the chassis.
+- **No peer URLs.** Engines never call other nodes by URL. If you need another node, dispatch a `TransportPacket` through the chassis client.
+- **No transport authority.** Engines do not validate signatures, mint JWTs, or enforce gate policy.
+- **No orchestration.** Multi-step workflows live in the orchestrator node, not in engine handlers.
+- **No `eval`, `exec`, `pickle.loads`, `yaml.load` (use `yaml.safe_load`).** Banned by `tools/auditors`.
+
+## Contracts that govern this directory
+
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — the only request/response shape allowed across the engine boundary.
+- [`/contracts/runtime/runtime.contract.yaml`](../contracts/runtime/runtime.contract.yaml) — handler invariants and execution semantics.
+- [`/contracts/governance/tenant_context.contract.yaml`](../contracts/governance/tenant_context.contract.yaml) — every handler must preserve `tenant_context` on the response packet.
+- [`/contracts/governance/prohibited_factors.contract.yaml`](../contracts/governance/prohibited_factors.contract.yaml) — fields the engine must never read for decisioning.
+
+## Handler contract
+
+```python
+from chassis.types import TransportPacket
+
+async def handler(packet: TransportPacket) -> TransportPacket:
+    # 1. Read inputs only from packet.payload and packet.tenant_context
+    # 2. Do work (pure or via injected services)
+    # 3. Return a new TransportPacket with the same correlation_id
+    ...
+```
+
+Handlers must be:
+- **Idempotent** for the same `(packet.id, packet.action)` tuple. The chassis may retry.
+- **Pure with respect to side effects** — all writes go through `engine/services/`, never directly to a global.
+- **Stateless across requests.** No module-level mutable state.
+- **Trace-preserving.** Call `packet.with_child_span(...)` when emitting downstream packets.
+
+## Quality gates
+
+- `tools/verify_contracts.py` — every handler must declare its `action` and packet types in `engine/handlers.py` and match a contract entry.
+- `tests/contracts/` — round-trip tests asserting handler I/O conforms to `transport_packet.schema.json`.
+- `tests/unit/engine/` — pure-logic coverage. Target: ≥ 90% line coverage on `engine/core/`.
+- `tools/auditors/` — static checks: no banned imports, no FastAPI in engine, no peer URL strings.
+
+## Conventions
+
+- File naming: `snake_case`. One handler module per `action_namespace`.
+- All packet types and actions are lowercase `snake_case`.
+- Logging: structured JSON via `engine/logging.py`. Never log raw `payload` — use redacted projections.
+- Errors: raise typed exceptions from `chassis/errors.py`; the chassis converts to `TransportPacket` error responses.

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,0 +1,51 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: infrastructure
+  tags: [infrastructure, docker, local-dev]
+  owner: platform
+  status: active
+-->
+
+# infrastructure/
+
+Local and shared infrastructure assets — Dockerfiles, Compose stacks, supporting service images. Things that are *infrastructure as artifacts*, distinct from `deploy/` which is *infrastructure as environments*.
+
+## Purpose
+
+Provide reproducible local environments and reusable container assets so that "works on my machine" and "works in prod" derive from the same artifacts.
+
+## What lives here
+
+| Path | Responsibility |
+|---|---|
+| `infrastructure/docker/` | Container images and Compose fragments for the node and its supporting services. |
+
+Use the root `Dockerfile` for development images, `Dockerfile.prod` for production images, and `infrastructure/docker/` for sidecars, dev databases, message brokers, and other services the node depends on locally.
+
+## What does NOT live here
+
+- **No environment-specific values.** Hostnames, secrets, sizes — those belong in `deploy/terraform/<env>/` or env files.
+- **No application code.** Engines and chassis stay where they are.
+- **No CI workflow definitions.** Those live in `.github/workflows/`.
+
+## Contracts that govern this directory
+
+- [`/contracts/registration/node_registration.contract.yaml`](../contracts/registration/node_registration.contract.yaml) — local Compose stacks must be capable of bringing up the registration handshake.
+- [`/contracts/observability/metrics.contract.yaml`](../contracts/observability/metrics.contract.yaml) — local stacks include the observability sidecars from `observability/`.
+
+## Quality gates
+
+- All Dockerfiles run `hadolint` clean.
+- Compose files validate with `docker compose config`.
+- Pinned base image digests; no floating `:latest` tags.
+- Distroless or `slim` bases for production images. Multi-stage builds enforced.
+
+## Conventions
+
+- Image names: `golden-repo/<role>:<sha>`, where `<role>` is one of `node`, `auditor`, `reviewer`.
+- One concern per Dockerfile. No combined frontend+backend images.
+- Health checks declared in the image, not patched on by Compose or k8s.
+- Volumes named, never anonymous, in any Compose file.

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,69 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: observability
+  tags: [observability, otel, prometheus, grafana, loki, alloy]
+  owner: platform
+  status: active
+-->
+
+# observability/
+
+The shipped observability stack: OpenTelemetry collector, Prometheus, Grafana, Loki, Alloy. Configurations, dashboards, alerts.
+
+## Purpose
+
+A node is only as operable as its observability surface. This directory ships the **default stack** that every node boots against locally and that production environments mirror.
+
+## What lives here
+
+| File / Group | Responsibility |
+|---|---|
+| `1_observability_telemetry.py` | Python OTel bootstrap used by `engine/main.py`; wires traces, metrics, logs. |
+| `1_config_otel-collector-config.yaml` | OTel collector pipelines: receive → process → export. |
+| `1_config_prometheus.yml`, `4_prometheus_config.yml`, `P2_4_prometheus_scrape.yml` | Prometheus scrape configurations. |
+| `1_config_grafana_datasources.yml` | Grafana datasource provisioning. |
+| `4_grafana_dashboard_metrics.json`, `P2_4_grafana_dashboard.json`, `P2_5_grafana_slo_dashboard.json` | Default dashboards: per-node SLIs, SLO error budgets. |
+| `5_prometheus_alert_rules.yml` | Alert rules for the SLI set in the metrics contract. |
+| `1_docker-compose.observability.yml` | Local stack — bring up the full pipeline with one command. |
+| `QW1_alloy_config.alloy`, `QW1_loki_config.yaml` | Log shipping via Grafana Alloy → Loki. |
+| `QW4_docker_compose_otel.yml`, `QW4_otel_collector_sampling.yaml` | Tail-based and head-based sampling configs. |
+
+## What does NOT live here
+
+- **No business metrics defined inline.** Domain-specific metrics are emitted from `engine/`, configured here.
+- **No production credentials.** All endpoints are env-driven.
+- **No source code beyond `1_observability_telemetry.py`.** This directory is config-first.
+
+## Contracts that govern this directory
+
+- [`/contracts/observability/metrics.contract.yaml`](../contracts/observability/metrics.contract.yaml) — required SLI metric set; every node must emit these.
+- [`/contracts/observability/trace_propagation.contract.yaml`](../contracts/observability/trace_propagation.contract.yaml) — W3C trace context propagation across the gate and between nodes.
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — `trace_id`, `span_id`, `correlation_id` fields the collector relies on.
+
+## Required SLIs
+
+Every node exposes:
+
+- `transport_requests_total{action,result}` — request counter.
+- `transport_request_duration_seconds{action}` — request latency histogram.
+- `gate_admit_total{decision}` — gate admit/deny counter.
+- `handler_errors_total{action,error_type}` — engine-side errors.
+- `node_info{node_id,version,layer}` — info gauge.
+
+Names and labels are normative. See `docs/observability/METRICS.md` for the full schema.
+
+## Quality gates
+
+- `tests/compliance/` asserts every required metric is exposed by the chassis.
+- Dashboards are JSON-validated in CI; broken JSON blocks merge.
+- Alert rules under `5_prometheus_alert_rules.yml` are linted by `promtool`.
+- The OTel collector config is validated by `otelcol validate` in CI.
+
+## Conventions
+
+- Metric names: `snake_case`, plural counters end in `_total`, histograms end in `_seconds` or `_bytes`.
+- Labels: low cardinality. `tenant_id` is **never** a metric label — it goes on traces and logs.
+- Dashboards: title `[Node] <Concern> — <Audience>`, e.g. `[Node] Gate — Operators`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,57 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: ops
+  tags: [scripts, ops, automation]
+  owner: platform
+  status: active
+-->
+
+# scripts/
+
+Operational scripts. Things you run **outside** the request path: at boot, at deploy, at audit time, in CI.
+
+## Purpose
+
+Hold the small, sharp tools that operate the service — wait-for, init, backup, restore, predeploy checks, contract alignment validation — without polluting the engine or chassis.
+
+## What lives here
+
+| Script | Purpose |
+|---|---|
+| `entrypoint.sh` | Container entrypoint shim used by the chassis Dockerfile. |
+| `init_runtime.py` | One-shot runtime initialisation (schema check, seed, capability negotiation). |
+| `wait_for_http.py` | Polls a URL until ready; used in compose and CI to gate dependent steps. |
+| `backup_runtime.sh`, `restore_runtime.sh` | Local-state backup/restore for development sandboxes. |
+| `predeploy_check.py` | Pre-deploy assertions: schema diff, contract compatibility, env required. |
+| `validate_contract_alignment.py` | Verifies engine handlers and chassis routes match `contracts/`. |
+| `validate-policy.sh` | Runs OPA / semgrep policy bundles locally. |
+| `review-local.sh` | Runs the full reviewer pipeline (`tools/review/`) against a local working copy. |
+| `changed-files.sh` | Helper for CI to scope checks to changed paths. |
+| `perplexity_audit_agent.py` | The L9 audit agent driver — invokes auditors in `tools/auditors/`. |
+
+## What does NOT live here
+
+- **No request-path code.** Anything called per packet belongs in `chassis/` or `engine/`.
+- **No deployment infra.** Terraform / k8s manifests live in `deploy/` and `infrastructure/`.
+- **No secrets.** Read from env or vault; never embedded.
+
+## Contracts that govern this directory
+
+- [`/contracts/registration/node_registration.contract.yaml`](../contracts/registration/node_registration.contract.yaml) — `init_runtime.py` honours the registration handshake.
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — `validate_contract_alignment.py` checks every handler against the canonical packet shape.
+
+## Quality gates
+
+- Every shell script: `set -euo pipefail`, `shellcheck` clean.
+- Every Python script: type-checked under `mypy.ini` strict profile, runs under `python -W error`.
+- No script may write outside its declared output dir without `--force`.
+- `predeploy_check.py` exits non-zero on any contract drift; CI gates merges on it.
+
+## Conventions
+
+- Idempotent by default. Re-running a script must not corrupt state.
+- Read configuration from the same env surface as the chassis (`.env.template`).
+- Emit structured logs to stderr; data to stdout. Never mix.

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,53 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: templates
+  tags: [templates, scaffolding, generators]
+  owner: platform
+  status: active
+-->
+
+# templates/
+
+Scaffolding the platform uses to generate new services, docs, and deploys. The **fingerprint** of a well-formed L9 artifact lives here.
+
+## Purpose
+
+When a developer runs `bootstrap.sh` or any generator, content is composed from this directory. The templates encode L9 invariants — headers, contracts, layout, naming — so that every generated artifact starts compliant.
+
+## What lives here
+
+| Path | Responsibility |
+|---|---|
+| `templates/service/` | New-service skeleton — chassis bindings, engine main, sample handler, contracts entry, README. |
+| `templates/deploy/` | Deploy scaffolds — Terraform module skeleton, deploy script outline. |
+| `templates/docs/` | Documentation templates — ADR, runbook, README skeletons matching `docs/`'s shape. |
+| `templates/dev.conf.template` | Developer-environment configuration template, copied to `.env` on bootstrap. |
+| `templates/styleguide.template.md` | Drop-in style guide for new services to ship `docs/STYLEGUIDE.md`. |
+
+## What does NOT live here
+
+- **No live service code.** Templates are *generators*, not running code. Imports here are checked but not executed in production.
+- **No environment-specific values.** Templates are env-agnostic; bootstrap fills in env values.
+- **No business logic.** Domain-specific patterns belong in `domains/example_domain/` and graduate into a real domain.
+
+## Contracts that govern this directory
+
+- [`/contracts/_schemas/l9_contract_meta.schema.json`](../contracts/_schemas/l9_contract_meta.schema.json) — every generated contract YAML validates against this meta-schema.
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — generated services ship handlers that comply with this canonical envelope.
+
+## Quality gates
+
+- Every template ships an L9_META header (HTML comment for Markdown, YAML comment for YAML).
+- `tools/auditors/` runs each template through a generator dry-run and asserts output is L9-compliant.
+- Template changes require a corresponding update to `tools/l9_template_manifest.yaml`.
+- Style guide template is matched against `docs/STYLEGUIDE.md` of every generated service.
+
+## Conventions
+
+- Template variables: `{{ snake_case_name }}`. No bare brace placeholders.
+- Templates fail fast — missing variables raise; never silently default.
+- Generated files include a comment line `# generated from templates/<path> — edits must be reflected upstream`.
+- Add a template only when the same scaffold has been hand-written ≥ 3 times.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,55 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: tests
+  tags: [tests, contracts, integration, compliance]
+  owner: platform
+  status: active
+-->
+
+# tests/
+
+Tests organised by **what they protect**, not by what they import.
+
+## Purpose
+
+The test suite is the executable specification of the node. It enforces contracts, exercises the gate, and validates engine behaviour against golden fixtures. Every PR keeps this suite green.
+
+## Layout
+
+| Path | Protects |
+|---|---|
+| `tests/unit/` | Pure-logic correctness. No I/O, no network, no fixtures heavier than a dict. Target: ≥ 90% line coverage on `engine/core/`. |
+| `tests/contracts/` | Round-trip every handler through `TransportPacket` (in) → handler → `TransportPacket` (out). Asserts conformance to `contracts/transport/transport_packet.schema.json` and per-action contract files. |
+| `tests/integration/` | End-to-end execute path through the chassis with a stub engine. Boots the FastAPI app in-process, exercises gate semantics. |
+| `tests/compliance/` | L9 template compliance — file inventory, headers, banned imports, contract meta-schema validity. |
+| `tests/review_fixtures/` | Golden inputs for the reviewer pipeline (`tools/review/`). Treat as immutable; updates require a fixture-change review. |
+| `tests/conftest.py` | Shared fixtures: ephemeral settings, packet factories, tenant context builders. |
+
+## What does NOT live here
+
+- **No live network calls.** Integration tests run against in-process stubs and ephemeral databases. Live calls belong in pre-deploy smoke tests under `scripts/predeploy_check.py`.
+- **No production secrets** — even in fixtures.
+- **No domain reach across slices.** A unit test for `engine/core/foo` does not import from `engine/core/bar`.
+
+## Contracts that govern this directory
+
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — `tests/contracts/` is the runtime check that this contract holds.
+- [`/contracts/gate/gate.contract.yaml`](../contracts/gate/gate.contract.yaml) — `tests/integration/` exercises the gate execute path described here.
+- [`/contracts/_schemas/l9_contract_meta.schema.json`](../contracts/_schemas/l9_contract_meta.schema.json) — `tests/compliance/` validates every contract YAML against this meta-schema.
+
+## Quality gates
+
+- `pytest` exits zero before any merge.
+- Coverage threshold enforced in `pyproject.toml`. Drops fail CI.
+- `tests/contracts/` must include at least one failing-shape test per action (negative case).
+- New handlers ship with: 1 unit test, 1 contract test, 1 integration test minimum.
+
+## Conventions
+
+- One test file per module under test. Mirror the source tree.
+- Use `pytest.mark.contract`, `pytest.mark.integration`, `pytest.mark.compliance` to scope CI shards.
+- Fixtures that build packets must use the canonical builder from `client/packet_builder.py` — never raw dict construction.
+- No `time.sleep` in tests; use injected clocks.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,59 @@
+<!--
+L9_META:
+  l9_schema: 1
+  origin: l9-template
+  engine: golden-repo
+  layer: tooling
+  tags: [tools, auditors, review, contracts, ci]
+  owner: platform
+  status: active
+-->
+
+# tools/
+
+Long-running automation: auditors, reviewers, contract verifiers, infra helpers, dev hooks. The codified knowledge of "what good looks like" in this repo.
+
+## Purpose
+
+`tools/` is where invariants are turned into checks. Anything that says *"this repo must be true"* — and runs in CI or on a developer's laptop to assert it — lives here.
+
+## What lives here
+
+| Path | Responsibility |
+|---|---|
+| `tools/auditors/` | Static and dynamic auditors. Detect banned imports, missing L9 headers, contract drift. |
+| `tools/review/` | The reviewer pipeline — `analyzers/`, `llm/prompts/`, `policy/`, `schemas/`. Powers the audit agent. |
+| `tools/audit_engine.py`, `audit_dispatch.py` | Orchestrates auditor runs and aggregates findings. |
+| `tools/verify_contracts.py` | Validates every YAML under `contracts/` against `contracts/_schemas/l9_contract_meta.schema.json`. |
+| `tools/dev/` | Developer utilities — local linters, generators, scaffolders. |
+| `tools/hooks/` | Pre-commit hook implementations referenced by `.pre-commit-config.yaml`. |
+| `tools/deploy/` | Helpers used by deploy scripts (image tagging, manifest mutation). |
+| `tools/infra/` | Helpers for environment bring-up that are too logic-heavy for `scripts/`. |
+| `tools/l9_template_manifest.yaml` | The authoritative file inventory enforced by template compliance checks. |
+| `tools/test.sh` | One-shot script that runs the audit + review + contract verify suite. |
+
+## What does NOT live here
+
+- **No request-path code.** The chassis and engines never import from `tools/`.
+- **No production secrets or service config.** Tools are inert outside CI/local dev.
+- **No domain logic.** Auditors are policy enforcers, not feature owners.
+
+## Contracts that govern this directory
+
+- [`/contracts/_schemas/l9_contract_meta.schema.json`](../contracts/_schemas/l9_contract_meta.schema.json) — meta-schema that `verify_contracts.py` enforces.
+- [`/contracts/transport/transport_packet.contract.yaml`](../contracts/transport/transport_packet.contract.yaml) — auditors check handlers against this.
+- [`/contracts/gate/gate.contract.yaml`](../contracts/gate/gate.contract.yaml) — auditors check the chassis execute path against this.
+
+## Quality gates
+
+- `tools/verify_contracts.py` runs in CI; non-zero blocks merge.
+- `tools/auditors/` runs in CI; a single FAIL blocks merge.
+- Reviewer prompts under `tools/review/llm/prompts/` are schema-validated against `tools/review/schemas/`.
+- Tools themselves are tested under `tests/unit/tools/` and `tests/compliance/`.
+
+## Conventions
+
+- Auditors emit findings as JSON on stdout. Schema in `tools/review/schemas/`.
+- Each auditor declares: `id`, `severity` (`block`, `warn`, `info`), `scope` (paths it inspects), `rationale`.
+- Reviewer prompts are versioned and immutable once shipped; new prompt → new prompt id.
+- New invariants are added by writing an auditor, not by patching the engine.


### PR DESCRIPTION
Adds the L9-aligned starter pack: canonical contracts, architecture and operations docs, ADR template, security and observability docs, and READMEs for every AI-system directory.

See `IMPLEMENTATION_NOTE.md` for the full file inventory.

**Note:** This branch was hardened by `chore/l9-pack-harden` (which fixes a YAML parser issue in `delegation_chain.contract.yaml` and accepts the canonical block-form L9_META headers in the verifiers). Recommended merge order: this PR → `feat/contracts-ci-wiring` → `chore/l9-pack-harden`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture, boundary, security, and operational documentation including setup guides, incident response runbooks, on-call procedures, and deployment guides.

* **Contracts**
  * Established canonical contracts for transport packets, governance, observability, routing policies, and node registration.
  * Added JSON schemas for contract validation and transport packet structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->